### PR TITLE
Fix issues with table wrapping/blocking on medium screen sizes

### DIFF
--- a/scss/_adk-table.scss
+++ b/scss/_adk-table.scss
@@ -27,8 +27,11 @@ table {
   }
   thead th {
     padding: $space $space-s;
+    white-space: nowrap; // Don't allow table headings to wrap
   }
   tr {
+    white-space: nowrap; // Don't allow table data to wrap
+
     transition: all $row-hover-time;
     .right {
       text-align: right;
@@ -63,7 +66,7 @@ table {
 }
 @include breakpoint(medium) {
   table {
-    display: table;
-    overflow-x: hidden;
+    overflow-x: auto;
+    display: block;
   }
 }


### PR DESCRIPTION
This will fix some issues with the responsive table tricks I added a while back:

**Old:**
![g7vl5tdo78](https://cloud.githubusercontent.com/assets/3157928/24778309/de36ccc8-1af7-11e7-855f-5518c688a476.gif)

**New:**
![z1ayb770ur](https://cloud.githubusercontent.com/assets/3157928/24778180/371b5724-1af7-11e7-9aef-9df46a39934d.gif)


## Note

Add a `width="100%"` to the `<th>` attribute that is the primary table item. The table needs to be told to fill the width of its container, and this will accomplish that.

```html
<div class="row expanded">
  <table class="hover">
    <thead>
      <tr>
        <th width="140">Brand</th>
        <th width="100%">Product Name</th> <!-- 100% here! -->
        <th>Status</th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td><a class="underline">Knoll</a></td>
        <td>Pollock Executive Chair</td>
        <td>Recommended</td>
      </tr>
    </tbody>
  </table>
</div>
```