### PR TITLE
Fix CORS issue in local development

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,13 @@ gulp.task('webserver', function() {
       port: 8080,
       open: true,
       livereload: false,
+      middleware: [cors],
     }));
+
+  function cors (req, res, next) {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    next();
+  }
 });
 
 // Default task


### PR DESCRIPTION
This will fix the CORS Allowed-Origin issues we often experience when pointing to a local Design Kit in development:

![image](https://cloud.githubusercontent.com/assets/3157928/24880984/663eccd2-1e0a-11e7-823c-2b56dcd3c735.png)

_Solution derived from https://github.com/AveVlad/gulp-connect/issues/100#issuecomment-96078162_