### PR TITLE
Add classes for field validation errors

### DIFF
--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -22,6 +22,11 @@ span.input-group-label {
   resize: horizontal;
 }
 
+// Set <select> "placeholder" color via .ng-empty
+select.ng-empty {
+  color: $input-placeholder-color;
+}
+
 /**
  * Form Errors
  *

--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -52,9 +52,28 @@ span.input-group-label {
   }
 }
 
+@mixin adk-selectize-error(
+  $background: $input-background-invalid,
+  $background-lighten: 10%
+) {
+  &:not(.focus) {
+    border-color: $background;
+    background-color: mix($background, $white, $background-lighten);
+    color: $background; // Make the text match the border
+
+    input::placeholder {
+      color: $background;
+    }
+  }
+}
+
 // Add form input error styles for Angular validator classes
 input.ng-invalid,
 select.ng-invalid,
 textarea.ng-invalid {
   @include adk-form-input-error;
+}
+
+.selectize-input.ng-invalid {
+  @include adk-selectize-error;
 }

--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -21,3 +21,40 @@ span.input-group-label {
 .no-v-resize {
   resize: horizontal;
 }
+
+/**
+ * Form Errors
+ *
+ * This is forked from /scss/forms/_error.scss in Foundation for Sites.
+ *
+ * We have copied Foundation's mixins and prefixed them with `adk-` so we can control all the aspects of form input errors explicitly.
+ *
+ * The original Foundation _error.scss file includes default variable values.
+ * We omitted the defaults in this file because they can still be overwritten in scss/_settings.scss if needed.
+ */
+
+/// Styles the background and border of an input field to have an error state.
+///
+/// @param {Color} $background [$alert-color] - Color to use for the background and border.
+/// @param {Number} $background-lighten [10%] - Lightness level of the background color.
+@mixin adk-form-input-error(
+  $background: $input-background-invalid,
+  $background-lighten: 10%
+) {
+  &:not(:focus) {
+    border-color: $background;
+    background-color: mix($background, $white, $background-lighten);
+    color: $background; // Make the text match the border
+
+    &::placeholder {
+      color: $background;
+    }
+  }
+}
+
+// Add form input error styles for Angular validator classes
+input.ng-invalid,
+select.ng-invalid,
+textarea.ng-invalid {
+  @include adk-form-input-error;
+}

--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -42,12 +42,12 @@ span.input-group-label {
   $background-lighten: 10%
 ) {
   &:not(:focus) {
-    border-color: $background;
+    border-color: get-color(alert);
     background-color: mix($background, $white, $background-lighten);
-    color: $background; // Make the text match the border
+    color: get-color(alert); // Make the text match the border
 
     &::placeholder {
-      color: $background;
+      color: get-color(alert);
     }
   }
 }
@@ -57,12 +57,12 @@ span.input-group-label {
   $background-lighten: 10%
 ) {
   &:not(.focus) {
-    border-color: $background;
+    border-color: get-color(alert);
     background-color: mix($background, $white, $background-lighten);
-    color: $background; // Make the text match the border
+    color: get-color(alert); // Make the text match the border
 
     input::placeholder {
-      color: $background;
+      color: get-color(alert);
     }
   }
 }

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -194,7 +194,7 @@ $hr-border: $global-separator;
 
 // $abide-inputs: true;
 // $abide-labels: true;
-// $input-background-invalid: get-color(alert);
+$input-background-invalid: $white;
 // $form-label-color-invalid: get-color(alert);
 // $input-error-color: get-color(alert);
 // $input-error-font-size: rem-calc(12);


### PR DESCRIPTION
This will add the Foundation Abide styles to the `.ng-invalid` classes so they will show up when Angular form validations fail.

![tstzzupnrl](https://cloud.githubusercontent.com/assets/3157928/24980139/ea92a7ba-1fa4-11e7-8699-f1a5947ce0d9.gif)
