### PR TITLE
Remove margin-bottom on .actionbar

### DIFF
--- a/scss/_adk-layout.scss
+++ b/scss/_adk-layout.scss
@@ -9,7 +9,6 @@
 // Action Bar
 .actionbar {
   @include flex-align(null, middle);
-  margin-bottom: $space-l;
   width: 100%;
   padding: $space-s 0;
   background-color: $white;


### PR DESCRIPTION
We previously added a `margin-bottom` to all `.actionbar` elements in https://github.com/Architizer/design-kit/pull/80

This is causing some breakage on the layout:
![screen shot 2017-04-13 at 6 21 40 pm](https://cloud.githubusercontent.com/assets/3157928/25026758/32106c40-2076-11e7-9442-b0b7e8ccc1b2.png)

This pull request removes this margin.