### PR TITLE
Darell/fix tooltip padding

### DIFF
--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -74,11 +74,6 @@
       margin: 0;
     }
   }
-
-  // Overwrite padding on all card contents
-  * {
-    padding: 0;
-  }
 }
 
 /**

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -617,7 +617,7 @@ $thumbnail-border: none;
 // $has-tip-border-bottom: dotted 1px $dark-gray;
 // $tooltip-background-color: $black;
 // $tooltip-color: $white;
-// $tooltip-padding: 0.75rem;
+$tooltip-padding: $space-xs;
 // $tooltip-font-size: $small-font-size;
 // $tooltip-pip-width: 0.75rem;
 // $tooltip-pip-height: $tooltip-pip-width * 0.866;


### PR DESCRIPTION
- Remove padding on card content in `_.adk-cards.scss` as it isn't being used and it is interfering with the tooltip padding for the Shortlist/Dismiss buttons.
- Added tooltip padding of `$space-xs` in `_.settings.scss`

![screen shot 2017-04-18 at 10 41 44 am](https://cloud.githubusercontent.com/assets/11481550/25136682/a9e0afe0-2423-11e7-87b3-a3f9988eeb95.png)

![screen shot 2017-04-18 at 10 41 31 am](https://cloud.githubusercontent.com/assets/11481550/25136696/aeddedd2-2423-11e7-984f-935f2afa188c.png)
