### PR TITLE
Override label font size with 'small' from the ADK scale

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -374,7 +374,7 @@ $input-prefix-border: $global-outline;
 $input-prefix-border-hover: 1px solid $adk-quicksilver;
 // $input-prefix-padding: 1rem;
 $form-label-color: $adk-quicksilver;
-// $form-label-font-size: rem-calc(14);
+$form-label-font-size: $font-size-s;
 // $form-label-font-weight: $global-weight-normal;
 // $form-label-line-height: 1.8;
 // $select-background: $white;


### PR DESCRIPTION
Ultimately, a typography pass of foundation should override all `rem-calc`d font-sizes to match our scaling system, or (worse, but faster) override `rem-calc`. 

This is to apply our font size to input labels, currently being used on Source.