### PR TITLE
Orbit Styles

### DIFF
--- a/scss/_adk-orbit.scss
+++ b/scss/_adk-orbit.scss
@@ -6,7 +6,6 @@
 
 .orbit-container {
   height: auto !important;
-  max-height: 500px;
 }
 
 .orbit-bullets {

--- a/scss/_adk-orbit.scss
+++ b/scss/_adk-orbit.scss
@@ -27,3 +27,8 @@
     text-align: center;
   }
 }
+
+.orbit-next,
+.orbit-previous {
+  cursor: pointer;
+}

--- a/scss/_adk-type.scss
+++ b/scss/_adk-type.scss
@@ -28,6 +28,7 @@ p > a {
   color: $black;
   text-decoration: none;
   border-bottom: 1px solid rgba($adk-blue, 0.6);
+  word-wrap: break-word;
   &:hover {
     border-bottom: 1px solid $adk-blue;
   }


### PR DESCRIPTION
This changes a few lines in the orbit styles.

- Pointer cursor on the previous/next buttons
- No more max-height (we are now handling the height of the orbit via image size through imgix)
- Another small fix for links in paragraphs not breaking on line breaks