### PR TITLE
Add color classes for :hover

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -118,6 +118,11 @@ These colors are surfaced as utility classes in the format below:
 * `.bg-{color}` sets the `background-color` CSS property
 * `.border-{color}` sets the `border-color` CSS property
 
+Or to set `:hover` colors:
+* `.hover-{color}` sets the `color` CSS property on hover
+* `.hover-bg-{color}` sets the `background-color` CSS property on hover
+* `.hover-border-{color}` sets the `border-color` CSS property on hover
+
 where:
 * `{color}` is the name of the color
 
@@ -147,6 +152,12 @@ These colors are surfaced as utility classes in the format below:
 * `.{color}-{shade}` sets the `color` CSS property  (to specify the shade)
 * `.bg-{color}-{shade}` sets the `background-color` CSS property
 * `.border-{color}-{shade}` sets the `border-color` CSS property
+
+Or to set `:hover` colors:
+* `.hover-{color}` sets the `color` CSS property on hover (uses the *500* shade for this color)
+* `.hover-{color}-{shade}` sets the `color` CSS property on hover
+* `.hover-bg-{color}-{shade}` sets the `background-color` CSS property on hover
+* `.hover-border-{color}-{shade}` sets the `border-color` CSS property on hover
 
 where:
 * `{color}` is the name of the color

--- a/scss/_adk-colors.scss
+++ b/scss/_adk-colors.scss
@@ -26,19 +26,19 @@
     .#{$name}-#{$shade} {
       color: $value !important;
     }
-    .hover-#{$name}-#{$shade} {
+    .hover-#{$name}-#{$shade}:hover {
       color: $value !important;
     }
     .bg-#{$name}-#{$shade} {
       background-color: $value !important;
     }
-    .hover-bg-#{$name}-#{$shade} {
+    .hover-bg-#{$name}-#{$shade}:hover {
       background-color: $value !important;
     }
     .border-#{$name}-#{$shade} {
       border-color: $value !important;
     }
-    .hover-border-#{$name}-#{$shade} {
+    .hover-border-#{$name}-#{$shade}:hover {
       border-color: $value !important;
     }
   }

--- a/scss/_adk-colors.scss
+++ b/scss/_adk-colors.scss
@@ -4,10 +4,19 @@
   .#{$name} {
     color: $color !important;
   }
+  .hover-#{$name}:hover {
+    color: $color !important;
+  }
   .bg-#{$name} {
     background-color: $color !important;
   }
+  .hover-bg-#{$name}:hover {
+    background-color: $color !important;
+  }
   .border-#{$name} {
+    border-color: $color !important;
+  }
+  .hover-border-#{$name}:hover {
     border-color: $color !important;
   }
 
@@ -17,10 +26,19 @@
     .#{$name}-#{$shade} {
       color: $value !important;
     }
+    .hover-#{$name}-#{$shade} {
+      color: $value !important;
+    }
     .bg-#{$name}-#{$shade} {
       background-color: $value !important;
     }
+    .hover-bg-#{$name}-#{$shade} {
+      background-color: $value !important;
+    }
     .border-#{$name}-#{$shade} {
+      border-color: $value !important;
+    }
+    .hover-border-#{$name}-#{$shade} {
       border-color: $value !important;
     }
   }
@@ -31,10 +49,19 @@
   .#{$name} {
     color: $color !important;
   }
+  .hover-#{$name}:hover {
+    color: $color !important;
+  }
   .bg-#{$name} {
     background-color: $color !important;
   }
+  .hover-bg-#{$name}:hover {
+    background-color: $color !important;
+  }
   .border-#{$name} {
+    border-color: $color !important;
+  }
+  .hover-border-#{$name}:hover {
     border-color: $color !important;
   }
 }

--- a/scss/_adk-variables.scss
+++ b/scss/_adk-variables.scss
@@ -120,6 +120,9 @@ $adk-yellow: #ffcd00;
 $adk-quicksilver: #859DAF;
 $adk-gunmetal: #b8c8d1;
 
+$adk-global-separator-color: rgba($adk-quicksilver, 0.3);
+$adk-global-separator: 1px solid $adk-global-separator-color;
+
 $adk-palette-colors: (
   blue: $adk-blue,
   green: $adk-green,
@@ -128,6 +131,7 @@ $adk-palette-colors: (
   quicksilver: $adk-quicksilver,
   gunmetal: $adk-gunmetal,
   gray: $medium-gray,
+  global-separator: $adk-global-separator-color,
 );
 
 $adk-neutral-colors: (

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -67,7 +67,7 @@ $global-weight-light: 300; //added
 $global-weight-bold: 800;
 $global-radius: $space-xxxs;
 $global-outline: 1px solid $adk-gunmetal;
-$global-separator: 1px solid rgba($adk-quicksilver, 0.3);
+$global-separator: $adk-global-separator;
 // $global-text-direction: ltr;
 // $global-flexbox: false;
 // $print-transparent-backgrounds: true;


### PR DESCRIPTION
These changes add utility classes for setting `:hover` colors.

Prefix any of our existing color classes with `hover-` and it will define the hover behavior on that element with that color.

Example:
![zgcy0z41pv](https://cloud.githubusercontent.com/assets/3157928/26378991/ee7ab786-3fe4-11e7-9ada-5db5a14caad9.gif)

```html
<div class="bg-extra-light-gray hover-bg-red-50 border-gray hover-border-red">
  <a class="gray hover-red">A gray link that turns red on hover inside of a box with an extra-light-gray background that turns red-50 on hover and a gray border that turns red on hover</a>
</div>
```
