### PR TITLE
Use ".secondary-light" styles for selected items in Selectize

### DIFF
--- a/scss/_adk-selectize.scss
+++ b/scss/_adk-selectize.scss
@@ -197,12 +197,13 @@
   cursor: pointer;
   margin: 0 3px 3px 0;
   padding: $space-micro $space-xs;
-  background: $adk-blue;
-  color: $white;
+  background: rgba($adk-gunmetal, 0.25); // Derived from .secondary-light in button styles
+  color: $black;
   border-radius: $global-radius;
 }
 .selectize-control.multi .selectize-input > div:hover {
-  background: darken($adk-blue, 10);
+  background: $adk-gunmetal; // Derived from .secondary-light in button styles
+  color: $white;
 }
 // .selectize-control.multi .selectize-input > div.active {
 //   background: #e8e8e8;


### PR DESCRIPTION
This changes the selected items in Selectize elements to use the `.secondary-light` styles from our ADK buttons:

![5vogdiamqf](https://cloud.githubusercontent.com/assets/3157928/26834647/e66adfd4-4aa3-11e7-9c4a-cf8445f5d253.gif)

*Note: merging this pull request **will change these styles in production** - test with the `?adk=0787d97` development build method first.*