### PR TITLE
Allow .dropdown-pane to be colors other than $white

### DIFF
--- a/scss/_adk-menu.scss
+++ b/scss/_adk-menu.scss
@@ -78,6 +78,6 @@ ul {
   box-shadow: 0 0 12px rgba($black,.22);
   -webkit-box-shadow: 0 0 12px rgba($black,.22);
   padding: $space-xs 0;
-  background-color: $white !important;
+  background-color: $white;
   z-index: 1000;
 }

--- a/scss/_adk-tooltip.scss
+++ b/scss/_adk-tooltip.scss
@@ -1,0 +1,3 @@
+.tooltip {
+  max-width: 16rem;
+}

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -619,7 +619,7 @@ $thumbnail-border: none;
 // $tooltip-color: $white;
 $tooltip-padding: $space-xs;
 // $tooltip-font-size: $small-font-size;
-// $tooltip-pip-width: 0.75rem;
+$tooltip-pip-width: $space-xxs;
 // $tooltip-pip-height: $tooltip-pip-width * 0.866;
 // $tooltip-radius: $global-radius;
 

--- a/scss/adk.scss
+++ b/scss/adk.scss
@@ -74,6 +74,7 @@
 @import 'adk-selectize';
 @import 'adk-spacing';
 @import 'adk-table';
+@import 'adk-tooltip';
 @import 'adk-type';
 
 // Architizer Design Kit mixins


### PR DESCRIPTION
This fixes an issue with dropdown panes that prevented us from overriding their background colors with other utility classes:

**Old:**
![image](https://user-images.githubusercontent.com/3157928/26845755-83147c52-4ac5-11e7-9690-ea134cc54317.png)
**Fixed:**
![image](https://user-images.githubusercontent.com/3157928/26845770-923b99c2-4ac5-11e7-9643-e4de3821aa17.png)
