### PR TITLE
Fix broken docs pages

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -505,6 +505,7 @@ These are ADK Avatars
     <div class="avatar small"><span class="initials">PK</span></div>
     <div class="avatar"><span class="initials">PK</span></div>
     <div class="avatar large"><span class="initials">PK</span></div>
+  </div>
 </div>
 ```
 ---


### PR DESCRIPTION
There was just a `</div>` missing - this fixes the docs pages beyond Images (UI / Forms / Tables / Spacing and Scale / Extensions)