### PR TITLE
Parsa/card hover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ npm_debug.log
 npm-debug.log
 docs/index.html
 css
+
+templates/masonry-grid.html

--- a/docs.md
+++ b/docs.md
@@ -742,7 +742,7 @@ Refer to [Foundation's Card Documentation](http://foundation.zurb.com/sites/docs
 <div class="row small-up-2 medium-up-3 large-up-4">
   <!-- Product Card 1-->
   <div class="column">
-    <div class="card clickable has-notification-dot" onclick="cardClick()">
+    <div class="card flex clickable has-notification-dot" onclick="cardClick()">
       <!-- Card Image -->
       <div class="card-section card-image card-image-no-margin"
            style="background-image: url('/docs/img/table.jpg')"></div>
@@ -785,7 +785,7 @@ Refer to [Foundation's Card Documentation](http://foundation.zurb.com/sites/docs
   </div>
   <!-- Product Card 2-->
   <div class="column">
-    <div class="card clickable" onclick="cardClick()">
+    <div class="card flex">
       <!-- Card Image -->
       <div class="card-section card-image card-image-no-margin"
            style="background-image: url('/docs/img/table.jpg')"></div>
@@ -799,92 +799,6 @@ Refer to [Foundation's Card Documentation](http://foundation.zurb.com/sites/docs
           </div>
           <!-- Middle Spacing -->
           <div class="columns"></div>
-          <!-- Dropdown Menu -->
-          <div class="columns shrink">
-            <ul class="dropdown menu"
-                data-dropdown-menu
-                data-alignment="right"
-                data-click-open="true"
-                data-disable-hover="true">
-              <li>
-                <span class=>
-                  <i class="material-icons" 
-                     style="cursor:pointer; width:1rem;">more_horiz2</i>
-                </span>
-                <ul class="menu">
-                  <li>
-                    <a>Shortlist</a>
-                  </li>
-                  <li>
-                    <a>Dismiss</a>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <!-- Product Name -->
-        <div class="row">
-          <strong class="ellipsis">Pollock Executive Chair</strong>
-        </div>
-        <!-- Brand Name -->
-        <div class="row align-middle">
-          <div class="columns shrink meta pr-0">
-            <a href="#"
-               target="_blank" 
-               class="underline">Knoll</a>
-          </div>
-          <!-- If Verified -->
-          <div class="columns shrink ml-xxs pl-0">
-            <span class="architizer-glyph blue-500">+</span>
-          </div>
-        </div>
-      </div>
-      <!-- View Product Button -->
-<!--       <div class="card-section">
-        <a class="primary hollow button expanded">View Product</a>
-      </div> -->
-    </div>
-  </div> 
-  <!-- Product Card 3-->
-  <div class="column">
-    <div class="card">
-      <!-- Card Image -->
-      <div class="card-section card-image card-image-no-margin"
-           style="background-image: url('/docs/img/table.jpg')"></div>
-      <!-- Card Content -->
-      <div class="card-section">
-        <!-- Response Marking and Dropdown Menu-->
-        <div class="row">
-          <!-- Response Marking -->
-          <div class="columns shrink">
-            <span class="caption blue">New Product</span>
-          </div>
-          <!-- Middle Spacing -->
-          <div class="columns"></div>
-          <!-- Dropdown Menu -->
-          <div class="columns shrink">
-            <ul class="dropdown menu"
-                data-dropdown-menu
-                data-alignment="right"
-                data-click-open="true"
-                data-disable-hover="true">
-              <li>
-                <span class=>
-                  <i class="material-icons" 
-                     style="cursor:pointer; width:1rem;">more_horiz2</i>
-                </span>
-                <ul class="menu">
-                  <li>
-                    <a>Shortlist</a>
-                  </li>
-                  <li>
-                    <a>Dismiss</a>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </div>
         </div>
         <!-- Product Name -->
         <div class="row">
@@ -910,32 +824,7 @@ Refer to [Foundation's Card Documentation](http://foundation.zurb.com/sites/docs
     </div>
   </div>
   <div class="column">
-    <div class="card">
-      <div class="card-section">
-        <div class="row">
-          <div class="columns">
-            <span class="caption blue">New Product</span>
-          </div>
-        </div>
-      </div>
-      <div class="card-section">
-        <div class="row">
-          <div class="medium-8 columns">
-            <strong>Product Title</strong>
-            <p>This card is a new product with our old button.</p>
-          </div>
-          <div class="columns">
-            <img src="/docs/img/table.jpg">
-          </div>
-        </div>
-      </div>
-      <div class="card-button">
-        <a href="#">View Product</a>
-      </div>
-    </div>
-  </div>
-  <div class="column">
-    <div class="card border-blue">
+    <div class="card flex border-blue">
       <div class="card-section">
       <p>A basic message with a blue outline</p>
       </div>

--- a/docs.md
+++ b/docs.md
@@ -696,9 +696,8 @@ Action Bars are title bars with other functionality inside them.
 ## Cards
 Card elements are modules that can be used across our UI, and are currently used for the most part in our conversation feed. 
 
-By default `.card` has a fixed width and `.card-image` has an aspect ratio of 4:3.  
-Use `.card.flex` to have a card be sized by the grid rather than a fixed width.  
-To change the aspect ratio from 4:3 to 16:9, use `.card-image.ratio-16-9`  
+By default `.card` is sized according to the flex grid. To make the cards have a fixed width, add `.masonry`, which is to be used in masonry grids and not the flex grid.  
+`.masonry` cards are sized according to the `.card-image` inside of it, which by default has an aspect ratio of 4:3. To change the aspect ratio from 4:3 to 16:9, use `.card-image.ratio-16-9` on the masonry cards. 
 
 
 ### Classes and Usage

--- a/docs.md
+++ b/docs.md
@@ -722,22 +722,25 @@ Action Bars are title bars with other functionality inside them.
 ---
 
 ## Cards
-Card elements are modules that can be used across our UI, and are currently used for the most part in our conversation feed. In these feeds cards can be basic messages, product activity/status cards, recommended products and more, but across the UI we should think of anything as being able to be a "card" that is reused across the system, e.g. product search criteria, so that we don't need to rebuild the same content over and over again when it appears in different places. Card componenets let us copy, paste and reuse.
+Card elements are modules that can be used across our UI, and are currently used for the most part in our conversation feed. 
 
-**A note about card spacing:**
-Because cards are self-contained elements, the top-level `.card` class handles the spacing/gutter inside the card. Therefore the only spacing that happens on elements inside cards is margin-bottom to control vertical spacing, defined by `$card-content-margin`.
+By default `.card` has a fixed width and `.card-image` has an aspect ratio of 4:3.  
+Use `.card.flex` to have a card be sized by the grid rather than a fixed width.  
+To change the aspect ratio from 4:3 to 16:9, use `.card-image.ratio-16-9`  
 
-### Usage
+
+### Classes and Usage
 The top level class for creating card elements is `.card`.
-- `.card.border-blue` - Class to create a blue outline.
 - `.card.clickable` - Add "clickable" to a card if it is an interactive element.
 - `.card.has-notification-dot` – A red notification dot is added to the top left corner of the card.
+- `.card .card-button` - This is our old style card action, which was a button embedded into the card itself. Used when cards are not in the context of a grid and are not clickable, eg. in the message thread.
 - `.card .caption` - To be used inside card headers to show the status or type of a card, if it's a product.
-- `.card .card-button` - This is our old style card action, which was a button embedded into the card itself. Potentially deprecated.
+- `.card.border-blue` - Class to create a blue outline.
 
 Refer to [Foundation's Card Documentation](http://foundation.zurb.com/sites/docs/card.html) for all card options.
 
 ### Examples
+The following are examples of `.flex` cards:  
 ```html_example
 <div class="row small-up-2 medium-up-3 large-up-4">
   <!-- Product Card 1-->
@@ -837,6 +840,113 @@ function cardClick() {
 }
 </script>
 ```
+
+### Card Overlays
+To overlay information over card images, `.image-overlay-info` to the `.card-image`.  
+Then simply add an empty `.overlay` div inside the image, as well as a `.info` div with the content to be overlayed.  
+This is currently used on Project cards to show more information about what's happening inside of it.
+
+```html_example
+<div class="row">
+  <div class="column">
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>    
+    <!-- Card 2 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
 ---
 
 ## Modals

--- a/scss/_adk-animations.scss
+++ b/scss/_adk-animations.scss
@@ -4,15 +4,15 @@
 
 // Refrerence: https://tympanus.net/codrops/2014/06/19/ideas-for-subtle-hover-effects/
 
-figure.search-hover .hover-overlay {
-  max-width: none;
-  width: -webkit-calc(100% + 50px);
-  width: calc(100% + 50px);
-  opacity: 0.7;
+
+
+figure.search-hover .overlay {
+  background-color: $dark-gray;
+  width: 100%;
+  height: 100%;
+  opacity: 0.0;
   -webkit-transition: opacity 0.35s, -webkit-transform 0.35s;
   transition: opacity 0.35s, transform 0.35s;
-  -webkit-transform: translate3d(-40px,0, 0);
-  transform: translate3d(-40px,0,0);
 }
 
 figure.search-hover figcaption {
@@ -40,27 +40,29 @@ figure.search-hover h2 {
 }
 
 figure.search-hover p {
-  color: rgba(255,255,255,0.8);
+  color: $white;
   opacity: 0;
   -webkit-transition: opacity 0.2s, -webkit-transform 0.35s;
   transition: opacity 0.2s, transform 0.35s;
 }
 
-figure.search-hover:hover img,
-figure.search-hover:hover p {
+.card:hover .overlay, {
+  opacity: 0.6;
+}
+
+.card:hover p {
   opacity: 1;
 }
 
-figure.search-hover:hover img,
-figure.search-hover:hover h2,
-figure.search-hover:hover p {
+
+.card:hover .overlay,
+.card:hover h2,
+.card:hover p {
   -webkit-transform: translate3d(0,0,0);
   transform: translate3d(0,0,0);
 }
 
-figure.search-hover:hover p {
-  -webkit-transition-delay: 0.05s;
-  transition-delay: 0.05s;
+.card:hover p {
   -webkit-transition-duration: 0.35s;
   transition-duration: 0.35s;
 }

--- a/scss/_adk-animations.scss
+++ b/scss/_adk-animations.scss
@@ -21,8 +21,8 @@
 
   .info {
     position: absolute;
-    // height: 90%;
-    width: inherit;
+    height: 100%;
+    width: 100%;
     padding: $space-l $space;
     opacity: 0.0;
     -ms-transform: scale(0.85); /* IE 9 */
@@ -30,6 +30,9 @@
     transform: scale(0.85);
     -webkit-transition: all 0.35s;
     transition: all 0.35s;
+    // .row {
+    //     height: 100%;
+    //   }
   }
 }
 

--- a/scss/_adk-animations.scss
+++ b/scss/_adk-animations.scss
@@ -6,7 +6,7 @@
 
 figure.search-hover .overlay {
   position: absolute;
-  background-color: $adk-quicksilver;
+  background-color: $dark-gray;
   border-radius: $space-xxxs $space-xxxs 0 0;
   width: 100%;
   height: 100%;
@@ -34,7 +34,7 @@ figure.search-hover .search-info {
 }
 
 .card:hover .overlay, {
-  opacity: 0.75;
+  opacity: 0.7;
 }
 
 .card:hover .search-info {

--- a/scss/_adk-animations.scss
+++ b/scss/_adk-animations.scss
@@ -1,0 +1,66 @@
+/*-----------------------------*/
+/***** Search Hover Effect *****/
+/*-----------------------------*/
+
+// Refrerence: https://tympanus.net/codrops/2014/06/19/ideas-for-subtle-hover-effects/
+
+figure.search-hover .hover-overlay {
+  max-width: none;
+  width: -webkit-calc(100% + 50px);
+  width: calc(100% + 50px);
+  opacity: 0.7;
+  -webkit-transition: opacity 0.35s, -webkit-transform 0.35s;
+  transition: opacity 0.35s, transform 0.35s;
+  -webkit-transform: translate3d(-40px,0, 0);
+  transform: translate3d(-40px,0,0);
+}
+
+figure.search-hover figcaption {
+  text-align: left;
+}
+
+figure.search-hover figcaption > div {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 2em;
+  width: 100%;
+  height: 50%;
+}
+
+figure.search-hover h2,
+figure.search-hover p {
+  -webkit-transform: translate3d(0,40px,0);
+  transform: translate3d(0,40px,0);
+}
+
+figure.search-hover h2 {
+  -webkit-transition: -webkit-transform 0.35s;
+  transition: transform 0.35s;
+}
+
+figure.search-hover p {
+  color: rgba(255,255,255,0.8);
+  opacity: 0;
+  -webkit-transition: opacity 0.2s, -webkit-transform 0.35s;
+  transition: opacity 0.2s, transform 0.35s;
+}
+
+figure.search-hover:hover img,
+figure.search-hover:hover p {
+  opacity: 1;
+}
+
+figure.search-hover:hover img,
+figure.search-hover:hover h2,
+figure.search-hover:hover p {
+  -webkit-transform: translate3d(0,0,0);
+  transform: translate3d(0,0,0);
+}
+
+figure.search-hover:hover p {
+  -webkit-transition-delay: 0.05s;
+  transition-delay: 0.05s;
+  -webkit-transition-duration: 0.35s;
+  transition-duration: 0.35s;
+}

--- a/scss/_adk-animations.scss
+++ b/scss/_adk-animations.scss
@@ -4,42 +4,44 @@
 
 // Reference: https://tympanus.net/codrops/2014/06/19/ideas-for-subtle-hover-effects/
 
-figure.search-hover .overlay {
-  position: absolute;
-  background-color: $dark-gray;
-  border-radius: $space-xxxs $space-xxxs 0 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0.0;
-  -webkit-transition: opacity 0.35s;
-  transition: opacity 0.35s;
-}
-
-figure.search-hover figcaption {
-  padding: $space-l $space;
+.image-overlay-info {
   text-align: left;
   color: $white;
+
+  .overlay {
+    position: absolute;
+    background-color: $dark-gray;
+    border-radius: $space-xxxs $space-xxxs 0 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0.0;
+    -webkit-transition: opacity 0.35s;
+    transition: opacity 0.35s;
+  }
+
+  .info {
+    position: absolute;
+    // height: 90%;
+    width: inherit;
+    padding: $space-l $space;
+    opacity: 0.0;
+    -ms-transform: scale(0.85); /* IE 9 */
+    -webkit-transform: scale(0.85); /* Safari */
+    transform: scale(0.85);
+    -webkit-transition: all 0.35s;
+    transition: all 0.35s;
+  }
 }
 
-figure.search-hover .search-info {
-  position: absolute;
-  height: 90%;
-  width: 90%;
-  opacity: 0.0;
-  -ms-transform: scale(0.85); /* IE 9 */
-  -webkit-transform: scale(0.85); /* Safari */
-  transform: scale(0.85);
-  -webkit-transition: all 0.35s;
-  transition: all 0.35s;
-}
-
-.card:hover .overlay, {
+.card:hover {
+  .overlay, {
   opacity: 0.7;
-}
-
-.card:hover .search-info {
-  opacity: 1.0;
-  -ms-transform: scale(1); /* IE 9 */
-  -webkit-transform: scale(1); /* Safari */
-  transform: scale(1);
+  }
+  
+  .info {
+    opacity: 1.0;
+    -ms-transform: scale(1); /* IE 9 */
+    -webkit-transform: scale(1); /* Safari */
+    transform: scale(1);
+  }
 }

--- a/scss/_adk-animations.scss
+++ b/scss/_adk-animations.scss
@@ -4,65 +4,42 @@
 
 // Refrerence: https://tympanus.net/codrops/2014/06/19/ideas-for-subtle-hover-effects/
 
-
-
 figure.search-hover .overlay {
+  position: absolute;
   background-color: $dark-gray;
+  border-radius: $space-xxxs $space-xxxs 0 0;
   width: 100%;
   height: 100%;
   opacity: 0.0;
-  -webkit-transition: opacity 0.35s, -webkit-transform 0.35s;
-  transition: opacity 0.35s, transform 0.35s;
+  -webkit-transition: opacity 0.35s;
+  transition: opacity 0.35s;
 }
 
 figure.search-hover figcaption {
+  padding: $space;
   text-align: left;
-}
-
-figure.search-hover figcaption > div {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  padding: 2em;
-  width: 100%;
-  height: 50%;
-}
-
-figure.search-hover h2,
-figure.search-hover p {
-  -webkit-transform: translate3d(0,40px,0);
-  transform: translate3d(0,40px,0);
-}
-
-figure.search-hover h2 {
-  -webkit-transition: -webkit-transform 0.35s;
-  transition: transform 0.35s;
-}
-
-figure.search-hover p {
   color: $white;
-  opacity: 0;
-  -webkit-transition: opacity 0.2s, -webkit-transform 0.35s;
-  transition: opacity 0.2s, transform 0.35s;
+}
+
+figure.search-hover .search-info {
+  position: absolute;
+  height: 90%;
+  width: 90%;
+  opacity: 0.0;
+  -ms-transform: scale(0.85); /* IE 9 */
+  -webkit-transform: scale(0.85); /* Safari */
+  transform: scale(0.85);
+  -webkit-transition: all 0.35s;
+  transition: all 0.35s;
 }
 
 .card:hover .overlay, {
   opacity: 0.6;
 }
 
-.card:hover p {
-  opacity: 1;
-}
-
-
-.card:hover .overlay,
-.card:hover h2,
-.card:hover p {
-  -webkit-transform: translate3d(0,0,0);
-  transform: translate3d(0,0,0);
-}
-
-.card:hover p {
-  -webkit-transition-duration: 0.35s;
-  transition-duration: 0.35s;
+.card:hover .search-info {
+  opacity: 1.0;
+  -ms-transform: scale(1); /* IE 9 */
+  -webkit-transform: scale(1); /* Safari */
+  transform: scale(1);
 }

--- a/scss/_adk-animations.scss
+++ b/scss/_adk-animations.scss
@@ -2,11 +2,11 @@
 /***** Search Hover Effect *****/
 /*-----------------------------*/
 
-// Refrerence: https://tympanus.net/codrops/2014/06/19/ideas-for-subtle-hover-effects/
+// Reference: https://tympanus.net/codrops/2014/06/19/ideas-for-subtle-hover-effects/
 
 figure.search-hover .overlay {
   position: absolute;
-  background-color: $dark-gray;
+  background-color: $adk-quicksilver;
   border-radius: $space-xxxs $space-xxxs 0 0;
   width: 100%;
   height: 100%;
@@ -16,7 +16,7 @@ figure.search-hover .overlay {
 }
 
 figure.search-hover figcaption {
-  padding: $space;
+  padding: $space-l $space;
   text-align: left;
   color: $white;
 }
@@ -34,7 +34,7 @@ figure.search-hover .search-info {
 }
 
 .card:hover .overlay, {
-  opacity: 0.6;
+  opacity: 0.75;
 }
 
 .card:hover .search-info {

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -5,7 +5,7 @@
   position: relative;
   display: inline-block;
   float: left;
-  margin-right: $space-xs;
+  margin-right: $space-s;
 
   // Small breakpoint width
   width: $card-size-small;

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -4,6 +4,7 @@
   overflow: initial;
   position: relative;
   display: inline-block;
+  float: left;
   margin-right: $space-xs;
 
   // Small breakpoint width

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -9,17 +9,25 @@
     margin-right: $space-xs;
     display: inline-block;
     // Small breakpoint width
-    width: $card-size-base;
+    width: $card-size-small;
+
+    .card-image {
+      height: $card-size-small / 1.33;  //4:3 by default
+      &.ratio-16-9 {
+        height: $card-size-small / 1.77;
+        width: inherit;
+      }
+    }
 
     // Medium breakpoint width
     @include breakpoint(medium) {
       width: $card-size-base;
-    }
-    .card-image {
-      height: $card-size-base / 1.33;  //4:3 by default
-      &.ratio-16-9 {
-        height: $card-size-base / 1.77;
-        width: inherit;
+      .card-image {
+        height: $card-size-base / 1.33;
+        &.ratio-16-9 {
+          height: $card-size-base / 1.77;
+          width: inherit;
+        }
       }
     }
   }
@@ -123,24 +131,17 @@
     margin-top: -$space;
   }
 
-  // &.ratio-16-9 {
-  //   height: $card-size-small / 1.77;
-  //   width: inherit;
-  // }
+  // Small breakpoint height
+  height: 5rem;
 
   // Medium breakpoint height
   @include breakpoint(medium) {
-    height: $card-size-base / 1.33;
-
-    &.ratio-16-9 {
-      height: $card-size-base / 1.77;
-      width: inherit;
-    }
+    height: 10rem;
   }
 
-  // // Large breakpoint height
-  // @include breakpoint(large) {
-  //   height: 15rem;
-  // }
-
+  // Large breakpoint height
+  @include breakpoint(large) {
+    height: 15rem;
+  }
 }
+

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -3,6 +3,8 @@
   padding: $card-padding;
   overflow: initial;
   position: relative;
+  display: inline-block;
+  margin-right: $space-xs;
 
   // Small breakpoint width
   width: $card-size-small;
@@ -15,6 +17,8 @@
   // Use flex class to overide fixed width and use the grid to size the card instead
   &.flex {
     width: inherit;
+    display: block;
+    margin-right: 0px;
   }
 
   &.clickable {

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -3,24 +3,33 @@
   padding: $card-padding;
   overflow: initial;
   position: relative;
-  display: inline-block;
-  float: left;
-  margin-right: $space-s;
 
-  // Small breakpoint width
-  width: $card-size-small;
-
-  // Medium breakpoint width
-  @include breakpoint(medium) {
+  &.masonry {
+    float: left;
+    margin-right: $space-xs;
+    display: inline-block;
+    // Small breakpoint width
     width: $card-size-base;
+
+    // Medium breakpoint width
+    @include breakpoint(medium) {
+      width: $card-size-base;
+    }
+    .card-image {
+      height: $card-size-base / 1.33;  //4:3 by default
+      &.ratio-16-9 {
+        height: $card-size-base / 1.77;
+        width: inherit;
+      }
+    }
   }
 
-  // Use flex class to overide fixed width and use the grid to size the card instead
-  &.flex {
-    width: inherit;
-    display: block;
-    margin-right: 0px;
-  }
+  // // Use flex class to overide fixed width and use the grid to size the card instead
+  // &.flex {
+  //   width: inherit;
+  //   display: block;
+  //   margin-right: 0px;
+  // }
 
   &.clickable {
     cursor: pointer;
@@ -105,7 +114,7 @@
   background-position: 50% 50%;
   background-repeat: no-repeat;
   background-size: cover;
-  height: $card-size-small / 1.33;  //4:3 by default
+  // height: $card-size-small / 1.33;  //4:3 by default
   width: inherit;
 
   &.card-image-no-margin {
@@ -114,10 +123,10 @@
     margin-top: -$space;
   }
 
-  &.ratio-16-9 {
-    height: $card-size-small / 1.77;
-    width: inherit;
-  }
+  // &.ratio-16-9 {
+  //   height: $card-size-small / 1.77;
+  //   width: inherit;
+  // }
 
   // Medium breakpoint height
   @include breakpoint(medium) {

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -62,10 +62,6 @@
     text-align: center;
   }
 
-  img {
-    border-radius: $global-radius;
-  }
-
   .card-section {
     margin: $card-content-margin;
     padding: 0;

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -4,6 +4,14 @@
   overflow: initial;
   position: relative;
 
+  // Small breakpoint width
+  width: $card-size-small;
+
+  // Medium breakpoint width
+  @include breakpoint(medium) {
+    width: $card-size-base;
+  }
+
   &.clickable {
     cursor: pointer;
     box-shadow: 0 0 0 2px transparent;
@@ -18,7 +26,7 @@
   }
 
   &.message {
-    min-width: 360px;
+    min-width: $card-size-base;
   }
 
   // Inactive cards
@@ -85,9 +93,12 @@
  */
 .card-image {
   position: relative;
+  border-radius: $space-xxxs $space-xxxs 0 0;
   background-position: 50% 50%;
   background-repeat: no-repeat;
   background-size: cover;
+  height: $card-size-small / 1.33;  //4:3 by default
+  width: inherit;
 
   &.card-image-no-margin {
     margin-left: -$space;
@@ -95,17 +106,24 @@
     margin-top: -$space;
   }
 
-  // Small breakpoint height
-  height: 5rem;
+  &.ratio-16-9 {
+    height: $card-size-small / 1.77;
+    width: inherit;
+  }
 
   // Medium breakpoint height
   @include breakpoint(medium) {
-    height: 10rem;
+    height: $card-size-base / 1.33;
+    
+    &.ratio-16-9 {
+      height: $card-size-base / 1.77;
+      width: inherit;
+    }
   }
 
-  // Large breakpoint height
-  @include breakpoint(large) {
-    height: 15rem;
-  }
+  // // Large breakpoint height
+  // @include breakpoint(large) {
+  //   height: 15rem;
+  // }
 
 }

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -90,6 +90,8 @@
  * Use with `style="background-image:url('/put/the/path/here')"`
  *
  * Add the .card-image-no-margin class to make the image extend outside the margins
+ * 
+ * Add the .ratio-16-9 to change the aspect ratio from 4:3 to 16:9
  */
 .card-image {
   position: relative;
@@ -114,7 +116,7 @@
   // Medium breakpoint height
   @include breakpoint(medium) {
     height: $card-size-base / 1.33;
-    
+
     &.ratio-16-9 {
       height: $card-size-base / 1.77;
       width: inherit;

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -95,6 +95,12 @@
     margin-top: -$space;
   }
 
+  .hover-overlay {
+    background-color: $dark-gray;
+    width: 100%;
+    height: 100%;
+  }
+
   // Small breakpoint height
   height: 5rem;
 

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -95,12 +95,6 @@
     margin-top: -$space;
   }
 
-  .hover-overlay {
-    background-color: $dark-gray;
-    width: 100%;
-    height: 100%;
-  }
-
   // Small breakpoint height
   height: 5rem;
 

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -12,6 +12,11 @@
     width: $card-size-base;
   }
 
+  // Use flex class to overide fixed width and use the grid to size the card instead
+  &.flex {
+    width: inherit;
+  }
+
   &.clickable {
     cursor: pointer;
     box-shadow: 0 0 0 2px transparent;

--- a/scss/_adk-variables.scss
+++ b/scss/_adk-variables.scss
@@ -163,6 +163,11 @@ $adk-neutral-colors: (
  */
 $card-content-margin: 0 0 $space-xxs 0;
 
+// Card sizes
+$card-size-base: 360px;
+$card-size-small: 240px;
+
+
 /**
  * Transitions
  */

--- a/scss/_adk-variables.scss
+++ b/scss/_adk-variables.scss
@@ -165,7 +165,7 @@ $card-content-margin: 0 0 $space-xxs 0;
 
 // Card sizes
 $card-size-base: 360px;
-$card-size-small: 240px;
+$card-size-small: 320px;
 
 
 /**

--- a/scss/adk.scss
+++ b/scss/adk.scss
@@ -59,6 +59,7 @@
 @include motion-ui-animations;
 
 // Architizer Design Kit styles
+@import 'adk-animations';
 @import 'adk-buttons';
 @import 'adk-colors';
 @import 'adk-cards';

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -16,11 +16,10 @@
       <div class="card clickable" style="margin: auto">
       <!-- Image -->
         <div class="card-section">
-          <figure class="card-image card-image-no-margin search-hover" style="background-image: url('/docs/img/table.jpg')">
+          <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('/docs/img/table.jpg')">
             <div class="overlay"></div>
-            <figcaption>
-              <div class="search-info">
-                <div class="row align-middle" style="height: 80%">
+              <div class="info">
+                <div class="row align-middle">
                 <h5>An Education Center in Philadelphia</h5>
                   <div class="small-4 columns">
                     <h2><strong>48</strong></h2>
@@ -36,8 +35,7 @@
                   </div>
                 </div>
               </div>
-            </figcaption>
-          </figure>
+          </div>
           </div>
         <!-- Text -->
         <div class="card-section">

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -10,8 +10,8 @@
 
   </head>
   <body>
-  <div class="row align-center" style="height: 100vh">
-    <div class="column small-3 align-self-middle">
+  <div class="row align-center align-middle" style="height: 100vh">
+    <div class="column small-3">
     <!-- Card -->
       <div class="card clickable">
       <!-- Image -->
@@ -21,7 +21,7 @@
             <figcaption>
               <div class="search-info">
                 <div class="row align-middle" style="height: 80%">
-                <h4>An Education Center in Philadelphia</h4>
+                <h5>An Education Center in Philadelphia</h5>
                   <div class="small-4 columns">
                     <h2><strong>48</strong></h2>
                     <h4>Products</h4>

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -16,7 +16,7 @@
       <div class="card clickable">
       <!-- Image -->
         <div class="card-section">
-          <figure class="card-image card-image-no-margin search-hover" style="background-image: url('https://architizer-prod.imgix.net/media/1494864703416-GenBrands_Element_Env01_ArtGallery.jpg?auto=format,compress&amp;cs=strip&amp;fit=crop&amp;q=60&amp;w=520')">
+          <figure class="card-image card-image-no-margin search-hover" style="background-image: url('/docs/img/table.jpg')">
             <div class="overlay"></div>
             <figcaption>
               <div class="search-info">

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -13,6 +13,7 @@
   <div class="row align-middle" style="height: 100vh">
     <div class="column">
       <!-- Flex Cards -->
+      <div class="row align-center mb-s"><div class="small-2 columns shrink"><span>Flex Cards</span></div></div>
       <div class="row align-center">
         <div class="small-3 column">
           <!-- Card 1 -->
@@ -114,6 +115,7 @@
         </div>
       </div>
       <!-- Masonry Cards -->
+      <div class="row align-center mb-s"><div class="small-2 columns shrink">.masonry Fixed Cards</span></div></div>
       <div class="row align-center">
         <div class="column shrink">
           <!-- Card 3 -->

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -11,9 +11,9 @@
   </head>
   <body>
   <div class="row align-center align-middle" style="height: 100vh">
-    <div class="column small-3">
+    <div class="column">
     <!-- Card -->
-      <div class="card clickable">
+      <div class="card clickable" style="margin: auto">
       <!-- Image -->
         <div class="card-section">
           <figure class="card-image card-image-no-margin search-hover" style="background-image: url('/docs/img/table.jpg')">

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -21,9 +21,18 @@
             <figcaption>
               <div class="search-info">
                 <h4>An Education Center in Philadelphia</h4>
-                <div class="row" style="height: 100%">
-                  <div class="small-4 columns align-self-middle">
-                    <p>An Education Center in Philadelphia</p>
+                <div class="row align-middle" style="height: 80%">
+                  <div class="small-4 columns">
+                    <h2>48</h2>
+                    <h4>Products</h4>
+                  </div>                  
+                  <div class="small-4 columns">
+                    <h2>22</h2>
+                    <h4>Searches</h4>
+                  </div>                  
+                  <div class="small-4 columns">
+                    <h2>61</h2>
+                    <h4>Messages</h4>
                   </div>
                 </div>
               </div>
@@ -53,32 +62,3 @@
   </script>
   </body>
 </html>
-
-
-
-
-
-      <div class="content">
-        <h2>Lily</h2>
-        <div class="grid">
-          <figure class="effect-lily">
-            <img src="img/12.jpg" alt="img12"/>
-            <figcaption>
-              <div>
-                <h2>Nice <span>Lily</span></h2>
-                <p>Lily likes to play with crayons and pencils</p>
-              </div>
-              <a href="#">View more</a>
-            </figcaption>     
-          </figure>
-          <figure class="effect-lily">
-            <img src="img/1.jpg" alt="img1"/>
-            <figcaption>
-              <div>
-                <h2>Nice <span>Lily</span></h2>
-                <p>Lily likes to play with crayons and pencils</p>
-              </div>
-              <a href="#">View more</a>
-            </figcaption>     
-          </figure>
-        </div>

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -11,12 +11,59 @@
   </head>
   <body>
   <div class="row align-center align-middle" style="height: 100vh">
-    <div class="column">
+    <div class="column shrink">
       <!-- Card 1 -->
-      <div class="card clickable" style="margin: auto">
+      <div class="card clickable">
       <!-- Image -->
         <div class="card-section">
           <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+            <div class="overlay"></div>
+            <div class="info">
+              <div class="row align-middle collapse" style="height: 100%;">
+                <div class="column">
+                  <div class="row column">
+                    <h5>An Education Center in UK</h5>
+                  </div>
+                  <div class="row mt-s mb-base">
+                    <div class="small-4 columns">
+                      <h2><strong>48</strong></h2>
+                      <h4>Products</h4>
+                    </div>
+                    <div class="small-4 columns">
+                      <h2><strong>22</strong></h2>
+                      <h4>Searches</h4>
+                    </div>
+                    <div class="small-4 columns">
+                      <h2><strong>61</strong></h2>
+                      <h4>Messages</h4>
+                    </div>
+                  </div>
+                  <!-- Team -->
+                  <div class="row column">
+                    <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                    <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                    <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Info -->
+        <div class="card-section">
+          <div class="row align-middle mt-s">
+            <div class="columns">
+              <h3 class="ellipsis">Hogwarts IV</h3>
+              <span class="fs-s">Construction Documents</span>
+            </div>
+          </div>
+        </div>
+      </div>      
+      <!-- Card 1 -->
+      <div class="card clickable">
+      <!-- Image -->
+        <div class="card-section">
+          <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
             <div class="overlay"></div>
             <div class="info">
               <div class="row align-middle collapse" style="height: 100%;">

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -10,98 +10,204 @@
 
   </head>
   <body>
-  <div class="row align-center align-middle" style="height: 100vh">
-    <div class="column shrink">
-      <!-- Card 1 -->
-      <div class="card clickable">
-      <!-- Image -->
-        <div class="card-section">
-          <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
-            <div class="overlay"></div>
-            <div class="info">
-              <div class="row align-middle collapse" style="height: 100%;">
-                <div class="column">
-                  <div class="row column">
-                    <h5>An Education Center in UK</h5>
-                  </div>
-                  <div class="row mt-s mb-base">
-                    <div class="small-4 columns">
-                      <h2><strong>48</strong></h2>
-                      <h4>Products</h4>
+  <div class="row align-middle" style="height: 100vh">
+    <div class="column">
+      <!-- Flex Cards -->
+      <div class="row align-center">
+        <div class="small-3 column">
+          <!-- Card 1 -->
+          <div class="card clickable">
+            <!-- Image -->
+            <div class="card-section">
+              <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+                <div class="overlay"></div>
+                <div class="info">
+                  <div class="row align-middle collapse" style="height: 100%;">
+                    <div class="column">
+                      <div class="row column">
+                        <h5>An Education Center in UK</h5>
+                      </div>
+                      <div class="row mt-s mb-base">
+                        <div class="small-4 columns">
+                          <h2><strong>48</strong></h2>
+                          <h4>Products</h4>
+                        </div>
+                        <div class="small-4 columns">
+                          <h2><strong>22</strong></h2>
+                          <h4>Searches</h4>
+                        </div>
+                        <div class="small-4 columns">
+                          <h2><strong>61</strong></h2>
+                          <h4>Messages</h4>
+                        </div>
+                      </div>
+                      <!-- Team -->
+                      <div class="row column">
+                        <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                        <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                        <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                      </div>
                     </div>
-                    <div class="small-4 columns">
-                      <h2><strong>22</strong></h2>
-                      <h4>Searches</h4>
-                    </div>
-                    <div class="small-4 columns">
-                      <h2><strong>61</strong></h2>
-                      <h4>Messages</h4>
-                    </div>
                   </div>
-                  <!-- Team -->
-                  <div class="row column">
-                    <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
-                    <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
-                    <div class="avatar small bg-green-300"><span class="initials">S</span></div>
-                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- Info -->
+            <div class="card-section">
+              <div class="row align-middle mt-s">
+                <div class="columns">
+                  <h3 class="ellipsis">Hogwarts IV</h3>
+                  <span class="fs-s">Construction Documents</span>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <!-- Info -->
-        <div class="card-section">
-          <div class="row align-middle mt-s">
-            <div class="columns">
-              <h3 class="ellipsis">Hogwarts IV</h3>
-              <span class="fs-s">Construction Documents</span>
+        <div class="small-3 column">
+          <!-- Card 2 -->
+          <div class="card clickable">
+            <!-- Image -->
+            <div class="card-section">
+              <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+                <div class="overlay"></div>
+                <div class="info">
+                  <div class="row align-middle collapse" style="height: 100%;">
+                    <div class="column">
+                      <div class="row column">
+                        <h5>An Education Center in UK</h5>
+                      </div>
+                      <div class="row mt-s mb-base">
+                        <div class="small-4 columns">
+                          <h2><strong>48</strong></h2>
+                          <h4>Products</h4>
+                        </div>
+                        <div class="small-4 columns">
+                          <h2><strong>22</strong></h2>
+                          <h4>Searches</h4>
+                        </div>
+                        <div class="small-4 columns">
+                          <h2><strong>61</strong></h2>
+                          <h4>Messages</h4>
+                        </div>
+                      </div>
+                      <!-- Team -->
+                      <div class="row column">
+                        <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                        <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                        <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      </div>      
-      <!-- Card 1 -->
-      <div class="card clickable">
-      <!-- Image -->
-        <div class="card-section">
-          <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
-            <div class="overlay"></div>
-            <div class="info">
-              <div class="row align-middle collapse" style="height: 100%;">
-                <div class="column">
-                  <div class="row column">
-                    <h5>An Education Center in UK</h5>
-                  </div>
-                  <div class="row mt-s mb-base">
-                    <div class="small-4 columns">
-                      <h2><strong>48</strong></h2>
-                      <h4>Products</h4>
-                    </div>
-                    <div class="small-4 columns">
-                      <h2><strong>22</strong></h2>
-                      <h4>Searches</h4>
-                    </div>
-                    <div class="small-4 columns">
-                      <h2><strong>61</strong></h2>
-                      <h4>Messages</h4>
-                    </div>
-                  </div>
-                  <!-- Team -->
-                  <div class="row column">
-                    <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
-                    <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
-                    <div class="avatar small bg-green-300"><span class="initials">S</span></div>
-                  </div>
+            <!-- Info -->
+            <div class="card-section">
+              <div class="row align-middle mt-s">
+                <div class="columns">
+                  <h3 class="ellipsis">Hogwarts IV</h3>
+                  <span class="fs-s">Construction Documents</span>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <!-- Info -->
-        <div class="card-section">
-          <div class="row align-middle mt-s">
-            <div class="columns">
-              <h3 class="ellipsis">Hogwarts IV</h3>
-              <span class="fs-s">Construction Documents</span>
+      </div>
+      <!-- Masonry Cards -->
+      <div class="row align-center">
+        <div class="column shrink">
+          <!-- Card 3 -->
+          <div class="card clickable masonry">
+            <!-- Image -->
+            <div class="card-section">
+              <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+                <div class="overlay"></div>
+                <div class="info">
+                  <div class="row align-middle collapse" style="height: 100%;">
+                    <div class="column">
+                      <div class="row column">
+                        <h5>An Education Center in UK</h5>
+                      </div>
+                      <div class="row mt-s mb-base">
+                        <div class="small-4 columns">
+                          <h2><strong>48</strong></h2>
+                          <h4>Products</h4>
+                        </div>
+                        <div class="small-4 columns">
+                          <h2><strong>22</strong></h2>
+                          <h4>Searches</h4>
+                        </div>
+                        <div class="small-4 columns">
+                          <h2><strong>61</strong></h2>
+                          <h4>Messages</h4>
+                        </div>
+                      </div>
+                      <!-- Team -->
+                      <div class="row column">
+                        <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                        <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                        <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- Info -->
+            <div class="card-section">
+              <div class="row align-middle mt-s">
+                <div class="columns">
+                  <h3 class="ellipsis">Hogwarts IV</h3>
+                  <span class="fs-s">Construction Documents</span>
+                </div>
+              </div>
+            </div>
+          </div>      
+          <!-- Card 4 -->
+          <div class="card clickable masonry">
+            <!-- Image -->
+            <div class="card-section">
+              <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+                <div class="overlay"></div>
+                <div class="info">
+                  <div class="row align-middle collapse" style="height: 100%;">
+                    <div class="column">
+                      <div class="row column">
+                        <h5>An Education Center in UK</h5>
+                      </div>
+                      <div class="row mt-s mb-base">
+                        <div class="small-4 columns">
+                          <h2><strong>48</strong></h2>
+                          <h4>Products</h4>
+                        </div>
+                        <div class="small-4 columns">
+                          <h2><strong>22</strong></h2>
+                          <h4>Searches</h4>
+                        </div>
+                        <div class="small-4 columns">
+                          <h2><strong>61</strong></h2>
+                          <h4>Messages</h4>
+                        </div>
+                      </div>
+                      <!-- Team -->
+                      <div class="row column">
+                        <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                        <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                        <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- Info -->
+            <div class="card-section">
+              <div class="row align-middle mt-s">
+                <div class="columns">
+                  <h3 class="ellipsis">Hogwarts IV</h3>
+                  <span class="fs-s">Construction Documents</span>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -20,18 +20,18 @@
             <div class="overlay"></div>
             <figcaption>
               <div class="search-info">
-                <h4>An Education Center in Philadelphia</h4>
                 <div class="row align-middle" style="height: 80%">
+                <h4>An Education Center in Philadelphia</h4>
                   <div class="small-4 columns">
-                    <h2>48</h2>
+                    <h2><strong>48</strong></h2>
                     <h4>Products</h4>
                   </div>                  
                   <div class="small-4 columns">
-                    <h2>22</h2>
+                    <h2><strong>22</strong></h2>
                     <h4>Searches</h4>
                   </div>                  
                   <div class="small-4 columns">
-                    <h2>61</h2>
+                    <h2><strong>61</strong></h2>
                     <h4>Messages</h4>
                   </div>
                 </div>

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -17,7 +17,17 @@
       <!-- Image -->
         <div class="card-section">
           <figure class="card-image card-image-no-margin search-hover" style="background-image: url('https://architizer-prod.imgix.net/media/1494864703416-GenBrands_Element_Env01_ArtGallery.jpg?auto=format,compress&amp;cs=strip&amp;fit=crop&amp;q=60&amp;w=520')">
-            <div class="hover-overlay"></div>
+            <div class="overlay"></div>
+            <figcaption>
+              <div class="search-info">
+                <h4>An Education Center in Philadelphia</h4>
+                <div class="row" style="height: 100%">
+                  <div class="small-4 columns align-self-middle">
+                    <p>An Education Center in Philadelphia</p>
+                  </div>
+                </div>
+              </div>
+            </figcaption>
           </figure>
           </div>
         <!-- Text -->
@@ -25,7 +35,7 @@
           <div class="row align-middle mt-s">
             <div class="columns">
               <h3 class="ellipsis">Hogwarts IV</h3>
-              <span><strong>3</strong> Searches</span>
+              <span class="fs-s">Construction Documents</span>
             </div>
           </div>
         </div>

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -12,32 +12,44 @@
   <body>
   <div class="row align-center align-middle" style="height: 100vh">
     <div class="column">
-    <!-- Card -->
+    <!-- Card 1 -->
       <div class="card clickable" style="margin: auto">
       <!-- Image -->
         <div class="card-section">
-          <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('/docs/img/table.jpg')">
+          <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
             <div class="overlay"></div>
-              <div class="info">
-                <div class="row align-middle">
-                <h5>An Education Center in Philadelphia</h5>
-                  <div class="small-4 columns">
-                    <h2><strong>48</strong></h2>
-                    <h4>Products</h4>
-                  </div>                  
-                  <div class="small-4 columns">
-                    <h2><strong>22</strong></h2>
-                    <h4>Searches</h4>
-                  </div>                  
-                  <div class="small-4 columns">
-                    <h2><strong>61</strong></h2>
-                    <h4>Messages</h4>
+            <div class="info">
+              <div class="row align-middle collapse" style="height: 100%;">
+                <div class="column">
+                  <div class="row column">
+                    <h5>An Education Center in Philadelphia</h5>
+                  </div>
+                  <div class="row mt-s mb-base">
+                    <div class="small-4 columns">
+                      <h2><strong>48</strong></h2>
+                      <h4>Products</h4>
+                    </div>
+                    <div class="small-4 columns">
+                      <h2><strong>22</strong></h2>
+                      <h4>Searches</h4>
+                    </div>
+                    <div class="small-4 columns">
+                      <h2><strong>61</strong></h2>
+                      <h4>Messages</h4>
+                    </div>
+                  </div>
+                  <!-- Team -->
+                  <div class="row column">
+                    <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                    <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                    <div class="avatar small bg-green-300"><span class="initials">S</span></div>
                   </div>
                 </div>
               </div>
+            </div>
           </div>
-          </div>
-        <!-- Text -->
+        </div>
+        <!-- Info -->
         <div class="card-section">
           <div class="row align-middle mt-s">
             <div class="columns">

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html class="adk no-js" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Architizer Design Kit Starter Template</title>
+    <!-- Architizer Design Kit CSS -->
+    <link rel="stylesheet" href="/css/adk.css" />
+
+  </head>
+  <body>
+  <div class="row align-center" style="height: 100vh">
+    <div class="column small-3 align-self-middle">
+    <!-- Card -->
+      <div class="card clickable">
+      <!-- Image -->
+        <div class="card-section">
+          <figure class="card-image card-image-no-margin search-hover" style="background-image: url('https://architizer-prod.imgix.net/media/1494864703416-GenBrands_Element_Env01_ArtGallery.jpg?auto=format,compress&amp;cs=strip&amp;fit=crop&amp;q=60&amp;w=520')">
+            <div class="hover-overlay"></div>
+          </figure>
+          </div>
+        <!-- Text -->
+        <div class="card-section">
+          <div class="row align-middle mt-s">
+            <div class="columns">
+              <h3 class="ellipsis">Hogwarts IV</h3>
+              <span><strong>3</strong> Searches</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Page content ends here -->
+  <!-- JavaScript dependencies -->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/what-input/2.1.1/what-input.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/6.3.1/js/foundation.min.js"></script>
+  <script>
+    $(document).foundation();
+  </script>
+  </body>
+</html>
+
+
+
+
+
+      <div class="content">
+        <h2>Lily</h2>
+        <div class="grid">
+          <figure class="effect-lily">
+            <img src="img/12.jpg" alt="img12"/>
+            <figcaption>
+              <div>
+                <h2>Nice <span>Lily</span></h2>
+                <p>Lily likes to play with crayons and pencils</p>
+              </div>
+              <a href="#">View more</a>
+            </figcaption>     
+          </figure>
+          <figure class="effect-lily">
+            <img src="img/1.jpg" alt="img1"/>
+            <figcaption>
+              <div>
+                <h2>Nice <span>Lily</span></h2>
+                <p>Lily likes to play with crayons and pencils</p>
+              </div>
+              <a href="#">View more</a>
+            </figcaption>     
+          </figure>
+        </div>

--- a/templates/card-hover.html
+++ b/templates/card-hover.html
@@ -12,7 +12,7 @@
   <body>
   <div class="row align-center align-middle" style="height: 100vh">
     <div class="column">
-    <!-- Card 1 -->
+      <!-- Card 1 -->
       <div class="card clickable" style="margin: auto">
       <!-- Image -->
         <div class="card-section">
@@ -22,7 +22,7 @@
               <div class="row align-middle collapse" style="height: 100%;">
                 <div class="column">
                   <div class="row column">
-                    <h5>An Education Center in Philadelphia</h5>
+                    <h5>An Education Center in UK</h5>
                   </div>
                   <div class="row mt-s mb-base">
                     <div class="small-4 columns">

--- a/templates/masonry-grid.html
+++ b/templates/masonry-grid.html
@@ -1,0 +1,1443 @@
+<!doctype html>
+<html class="adk no-js" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Architizer Design Kit Starter Template</title>
+    <!-- Architizer Design Kit CSS -->
+    <link rel="stylesheet" href="/css/adk.css" />
+
+  </head>
+  <body>
+  <div id="container">
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>      
+    <!-- Card 1 -->
+    <div class="card clickable">
+    <!-- Image -->
+      <div class="card-section">
+        <div class="card-image card-image-no-margin image-overlay-info ratio-16-9" style="background-image: url('https://architizer-prod.imgix.net/mediadata/projects/042013/cd7346ba.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520')">
+          <div class="overlay"></div>
+          <div class="info">
+            <div class="row align-middle collapse" style="height: 100%;">
+              <div class="column">
+                <div class="row column">
+                  <h5>An Education Center in UK</h5>
+                </div>
+                <div class="row mt-s mb-base">
+                  <div class="small-4 columns">
+                    <h2><strong>48</strong></h2>
+                    <h4>Products</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>22</strong></h2>
+                    <h4>Searches</h4>
+                  </div>
+                  <div class="small-4 columns">
+                    <h2><strong>61</strong></h2>
+                    <h4>Messages</h4>
+                  </div>
+                </div>
+                <!-- Team -->
+                <div class="row column">
+                  <img class="avatar small" src="https://architizer-prod.imgix.net/media/1496789677388Thomas.jpg?auto=format,compress&cs=strip&fit=crop&q=60&w=520">
+                  <div class="avatar small bg-blue-300"><span class="initials">P</span></div>
+                  <div class="avatar small bg-green-300"><span class="initials">S</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Info -->
+      <div class="card-section">
+        <div class="row align-middle mt-s">
+          <div class="columns">
+            <h3 class="ellipsis">Hogwarts IV</h3>
+            <span class="fs-s">Construction Documents</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Page content ends here -->
+  <!-- JavaScript dependencies -->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/what-input/2.1.1/what-input.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/6.3.1/js/foundation.min.js"></script>
+  <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
+  <script>
+    $(document).foundation();
+  </script>
+  <script>
+    // jQuery
+    $('#container').masonry({
+      columnWidth: 380,
+      itemSelector: '.card.clickable'
+    });
+  </script>
+  </body>
+</html>


### PR DESCRIPTION
A fair amount here. Create an approach to add overlays to card images. To do this I also edited the way cards are built, giving them a fixed-width so that we can control the aspect ratio of the images inside them. I created a .flex class to be used on cards that just follow the grid, as they currently do. The fixed-width approach is going to be useful for when we start using the masonry grid to layout our cards, and it will give the UI a much tighter feel when things aren’t constantly resizing. 

![overlay](https://user-images.githubusercontent.com/4702134/27099865-3e08a9b4-504a-11e7-88e4-8697b2abbc21.gif)
