### PR TITLE
Add styles for "hero image" in thumbnails

### DIFF
--- a/scss/_adk-img.scss
+++ b/scss/_adk-img.scss
@@ -7,6 +7,7 @@
 
 .thumbnail {
   cursor: pointer;
+
   &.brand {
     width: $space-xxl;
     margin-bottom: 0;
@@ -19,6 +20,9 @@
     &.main {
       max-height: $space-xxxl;
     }
+  }
+  &.is-hero {
+    box-shadow: $thumbnail-shadow-hero;
   }
 }
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -595,6 +595,7 @@ $tab-content-border: none;
 $thumbnail-border: none;
 // $thumbnail-margin-bottom: $global-margin;
 // $thumbnail-shadow: 0 0 0 1px rgba($black, 0.2);
+$thumbnail-shadow-hero: 0 0 0 2px rgba($adk-blue, 1); // Added
 // $thumbnail-shadow-hover: 0 0 6px 1px rgba($primary-color, 0.5);
 // $thumbnail-transition: box-shadow 200ms ease-out;
 // $thumbnail-radius: $global-radius;


### PR DESCRIPTION
These changes add a style for `.thumbnail.is-hero` for use with our Attachments component:

![uploader](https://user-images.githubusercontent.com/3157928/28078603-6a840232-6633-11e7-9033-833237cc53b7.gif)