### PR TITLE
Remove transition box shadow from card style to avoid masonry reload flicker

### DIFF
--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -42,7 +42,7 @@
   &.clickable {
     cursor: pointer;
     box-shadow: 0 0 0 2px transparent;
-    transition: box-shadow, 0.12s;
+    // transition: box-shadow, 0.12s;
     &:hover {
       box-shadow: 0 0 16px rgba($adk-quicksilver, 0.7);
     }


### PR DESCRIPTION
- Remove transition box shadow from card styling to avoid reload flicker from happening for Masonry layouts

Note: needs to be merged before merging the PR for DEV-3707: https://github.com/Architizer/architizer-website/pull/1935