### PR TITLE
Add class to dim attachment images when non-hero

### DIFF
--- a/scss/_adk-img.scss
+++ b/scss/_adk-img.scss
@@ -21,8 +21,12 @@
       max-height: $space-xxxl;
     }
   }
+  &.can-hero {
+    opacity: 0.5;
+  }
   &.is-hero {
     box-shadow: $thumbnail-shadow-hero;
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
This adds a `.can-hero` class to set initial opacity for a thumbnail to 0.5 when attachments can be set as a hero image:
![jul-13-2017 17-48-49](https://user-images.githubusercontent.com/3157928/28189346-998216e8-67f3-11e7-9eb7-746a927ab798.gif)
