### PR TITLE
Add transparency to icon background

### DIFF
--- a/scss/_adk-fonts.scss
+++ b/scss/_adk-fonts.scss
@@ -66,6 +66,7 @@
   font-weight: normal;
   font-style: normal;
   font-size: 20px;  /* Preferred icon size */
+  background-color: transparent; /* IE does not render transparent bg by default. */
   display: inline-block;
   line-height: 1;
   vertical-align: middle;


### PR DESCRIPTION
<img width="112" alt="screen shot 2017-07-21 at 1 35 19 pm" src="https://user-images.githubusercontent.com/1562309/28475240-7879de82-6e19-11e7-910b-e2eac75ff3a5.png">
IE renders a dark grey background color behind the magnifying glass icon. (not pictured here)