### PR TITLE
Replace header link color with -gray for better active state contrast

### DIFF
--- a/scss/_adk-header.scss
+++ b/scss/_adk-header.scss
@@ -11,7 +11,7 @@
 
   // Links
   a {
-    color: map-get(generate-palette($adk-gray), 50);
+    color: $light-gray;
 
     &:hover {
       color: $white;


### PR DESCRIPTION
Fulfills the ADK portion for this ticket: https://architizer.atlassian.net/browse/DEV-4092 

- Replace the header link color (inactive state) with `$light-gray` for better contrast with the active states.

**_Note: Must be merged before this PR: https://github.com/Architizer/application/pull/3074_**

Recording: http://recordit.co/xEJnL3Ibqe 
