### PR TITLE
Add styles for search creation typeahead dropdown and input

### DIFF
--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -41,6 +41,18 @@ select.ng-empty {
   color: $input-placeholder-color;
 }
 
+.suggestion-list {
+  li {
+    color: black;
+  }
+  li:hover {
+    background-color: rgba(125, 168, 208, 0.2);
+  }
+  li.selected {
+    background-color: rgba(125, 168, 208, 0.2);
+  }
+}
+
 /**
  * Form Errors
  *

--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -43,7 +43,7 @@ select.ng-empty {
 
 .suggestion-list {
   li {
-    color: black;
+    color: $black;
   }
   li:hover {
     background-color: rgba(125, 168, 208, 0.2);

--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -46,10 +46,10 @@ select.ng-empty {
     color: $black;
   }
   li:hover {
-    background-color: rgba(125, 168, 208, 0.2);
+    background-color: $adk-typeahead-select;
   }
   li.selected {
-    background-color: rgba(125, 168, 208, 0.2);
+    background-color: $adk-typeahead-select;
   }
 }
 

--- a/scss/_adk-variables.scss
+++ b/scss/_adk-variables.scss
@@ -124,6 +124,8 @@ $adk-gray: $medium-gray;
 $adk-global-separator-color: rgba($adk-quicksilver, 0.3);
 $adk-global-separator: 1px solid $adk-global-separator-color;
 
+$adk-typeahead-select: rgba(125, 168, 208, 0.2);
+
 $adk-palette-colors: (
   blue: $adk-blue,
   green: $adk-green,


### PR DESCRIPTION
PR for the Search Creation modal typeahead styling: https://architizer.atlassian.net/browse/DEV-4011

**Note: Must be merged before the frontend portion: https://github.com/Architizer/architizer-website/pull/1987**

- Adds light blue background to the selected dropdown option
- Changes color of `<li>` text element to black

View changes here: 
Chrome: http://recordit.co/pufGXE5D9j
Safari: http://recordit.co/KTrnHds4Ea
Firefox: http://recordit.co/Bcrrgm90zT
IE: http://g.recordit.co/tk0ucTKfaI.gif

Opera/Yandex-friendly as well.