### PR TITLE
Refactor minimal fields to use less JavaScript

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1230,48 +1230,108 @@ Form elements in Foundation are styled based on their type attribute rather than
 ## Minimal Forms  
 "Minimal Fields" is the new styling for fields/forms that ADK is transitioning to. It was written based on [Material Design Fields](https://getmdl.io/components/index.html#textfields-section).
 
-To use it, wrap every field/label element in `.minimal-fields`. Add `.floating-label` to have the label animate out of the field on focus.  
+### Example
 
-See the [Minimal Fields Template](/templates/form.html) for a larger scale example.
-
-```html_example
-<div class="row align-left align-middle">
+<div class="row align-left">
   <div class="small-12 medium-8 large-6 xlarge-4 columns">
-    <form class="mt-s">
+    <form class="callout">
       <div class="row">
         <div class="columns">
           <div class="minimal-field floating-label">
-            <label>What are you looking for?
-            </label>
-            <input type="text">
+            <input type="text" class="ng-empty">
+            <label>What are you looking for?</label>
           </div>
         </div>
       </div>
       <div class="row">
         <div class="columns">
           <div class="minimal-field floating-label">
-            <label>What kind of product is this?
-            </label>
-            <select>
+            <select class="ng-empty">
               <option value=""></option>
               <option value="value">Starbuck</option>
               <option value="value">Hot Dog</option>
               <option value="value">Apollo</option>
             </select>
+            <label>What kind of product is this?</label>
           </div>
         </div>
       </div>
       <div class="row">
         <div class="columns">
-          <div class="minimal-field is-wrong floating-label">
-            <input type="text">
-            <label>This field threw an error.
-            </label>
+          <div class="minimal-field floating-label">
+            <textarea class="ng-empty" rows="4"></textarea>
+            <label>What other information can you provide?</label>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="columns">
+          <div class="minimal-field floating-label">
+            <input type="text" class="ng-invalid ng-empty" />
+            <label>What does an error look like?</label>
+            <span ng-messages=""><span>This is what an error looks like.</span></span>
           </div>
         </div>
       </div>
     </form>
   </div>
+</div>
+
+### Usage
+
+Add the classes `.minimal-field` and `.floating-label` to the parent element.
+
+**The HTML within the parent element must be structured in the following order:**
+1. Field (the input, select, or textarea element)
+1. Label (a label element)
+1. Errors (a span element with the ng-messages attribute set)
+
+See the following examples below:
+
+**Input**
+```html
+<div class="minimal-field floating-label">
+  <!-- Field -->
+  <input type="text" name="name" />
+  <!-- Label -->
+  <label>What are you looking for?</label>
+  <!-- Errors -->
+  <span ng-messages="YourCtrl.form['name'].$error">
+    <span ng-message="required">Required</span>
+    <span ng-message="maxlength">Please enter less than 60 characters</span>
+  </span>
+</div>
+```
+
+**Select**
+```html
+<div class="minimal-field floating-label">
+  <!-- Select -->
+  <select name="productType">
+    <option value="Starbuck">Starbuck</option>
+    <option value="Hot Dog">Hot Dog</option>
+    <option value="Apollo">Apollo</option>
+  </select>
+  <!-- Label -->
+  <label>What kind of product is this?</label>
+  <!-- Errors -->
+  <span ng-messages="YourCtrl.form['productType'].$error">
+    <span ng-message="required">Required</span>
+  </span>
+</div>
+```
+
+**Textarea**
+```html
+<div class="minimal-field floating-label">
+  <!-- Textarea -->
+  <textarea rows="4" name="description"></textarea>
+  <!-- Label -->
+  <label>What other information can you provide?</label>
+  <!-- Errors -->
+  <span ng-messages="YourCtrl.form['description'].$error">
+    <span ng-message="required">Required</span>
+  </span>
 </div>
 ```
 

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -1,19 +1,14 @@
 // Initialize Foundation
 $(document).foundation();
 
-//JQuery for minimal fields
+// Add fake `.ng-empty` classes to empty .minimal-field fields
 $(document).ready(function() {
-  $("input, textarea, select").focus(function(){
-    $(this).parent().addClass("is-focused");
-    $(this).focusout(function(){
-      $(this).parent().removeClass("is-focused");
-      if ($(this).val().length > 0){
-        $(this).parent().addClass("is-dirty");
-      }
-      if ($(this).val().length == 0){
-        $(this).parent().removeClass("is-dirty");
-      }
-    });
+  $(".minimal-field input, .minimal-field select, .minimal-field textarea").focusout(function(){
+    if ($(this).val().length > 0){
+      $(this).removeClass("ng-empty");
+    } else if ($(this).val().length === 0) {
+      $(this).addClass("ng-empty");
+    }
   });
 });
 

--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -156,7 +156,6 @@ $minimal-field-input-border-error: 2px solid $adk-red;
 // Regular field styles for minimal fields
 @mixin minimal-field-element {
   @include minimal-animation-default();
-  @include minimal-field-label;
 
   border: none;
   border-bottom: $minimal-field-input-border;
@@ -231,13 +230,14 @@ $minimal-field-input-border-error: 2px solid $adk-red;
   input,
   select,
   textarea {
+    @include minimal-field-label;
     @include minimal-field-element;
     @include minimal-field-element-errors;
   }
 
   // Selectize-specific
   .selectize-control {
-    @include minimal-field-label;
+    @include minimal-field-label; // <label> is a sibling of .selectize-control (not .selectize-input) so we have to specify this here
 
     .selectize-input {
       @include minimal-field-element;
@@ -248,7 +248,6 @@ $minimal-field-input-border-error: 2px solid $adk-red;
         padding: 0 !important; // !important because the regular Selectize styles get compiled later in the output CSS file, so they overwrite this rule without !important
       }
     }
-    
   }
 
   .selectize-dropdown {
@@ -270,16 +269,9 @@ $minimal-field-input-border-error: 2px solid $adk-red;
 
     // Filled/focused: Input/textarea
     input,
+    select,
     textarea {
       &:focus,
-      &:not(.ng-empty) {
-        @include minimal-field-filled-focused;
-      }
-    }
-
-    // Filled/focused: Select
-    select {
-      // Can't use :focus here because the label will still move up when the element is clicked even though it doesn't have a value yet
       &:not(.ng-empty) {
         @include minimal-field-filled-focused;
       }

--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -109,107 +109,93 @@ textarea.ng-invalid {
   transition-timing-function: $animation-curve-default;
 }
 
-/* ANIMATION */
 $animation-curve-fast-out-slow-in: cubic-bezier(0.4, 0, 0.2, 1) !default;
 $animation-curve-linear-out-slow-in: cubic-bezier(0, 0, 0.2, 1) !default;
 $animation-curve-fast-out-linear-in: cubic-bezier(0.4, 0, 1, 1) !default;
-
 $animation-curve-default: $animation-curve-fast-out-slow-in !default;
 
+// Borders
+$minimal-field-input-border: $input-border;
+$minimal-field-input-border-focus: $thick-underline-hover;
+$minimal-field-input-border-error: 2px solid $adk-red;
 
-// Floating Label Container
 .minimal-field {
   position: relative;
-  font-size: $input-font-size;
-  display: inline-block;
-  box-sizing: border-box;
-  width: 100%;
-  margin: 0;
-  padding: 0 0 $space 0;
-  // border: 0;
-  // border-bottom: $adk-global-separator;
+  margin: $space 0;
 
-  &.is-wrong, 
-  &.is-wrong.is-focused {
-    textarea, 
-    input,
-    select {
-      border-bottom: 2px solid $adk-red;
-    }
-    label {
-      color: $adk-red;
-    }
-  }
-
-  label {
-    font-weight: normal;
-  }
-
-  textarea {
-    min-height: 20px;
-  }
-
-  // Underlined Minimal Form Fields
-  textarea, 
+  // Field
   input,
-  select {
+  select,
+  textarea {
     @include minimal-animation-default();
     border: none;
-    border-bottom: $input-border;
-    // border-bottom: 1px solid rgba($adk-gunmetal, 0.0);
+    border-bottom: $minimal-field-input-border;
     border-radius: 0;
     background-color: transparent;
     box-shadow: none;
+    margin: 0;
     padding-left: 0;
-    resize: vertical;
+
     &:focus {
-      border: none;
-      border-bottom: $thick-underline-hover;
-      box-shadow: none;
+      border: 0;
+      border-bottom: $minimal-field-input-border-focus;
+    }
+
+    // Field errors
+    &.ng-invalid {
+      margin-bottom: 0;
+      border-bottom: $minimal-field-input-border-error;
+
+      // Red label
+      & + label {
+        color: $adk-red;
+      }
+
+      // Red error messages
+      & ~ span[ng-messages] {
+        color: $adk-red;
+        font-size: $font-size-s;
+      }
     }
   }
 
-  label{
-    font-weight: $global-weight-bold;
-  }
-
+  // Label
   &.floating-label {
     label {
       @include minimal-animation-default();
-      bottom: 0;
-      top: ($space-xxs);
       position: absolute;
       display: block;
+
+      bottom: 0;
+      top: $space-xxs;
+
       font-size: $input-font-size;
-      overflow: hidden;
-      white-space: nowrap;
-      pointer-events: none;
       font-weight: $global-weight-normal;
+
+      pointer-events: none;
     }
-    &.is-focused, 
-    &.is-dirty {
-      label {
-        font-size: $space-s;
-        font-weight: $global-weight-bold;
-        top: -$space;
-        visibility: visible;
+
+    // Focused/filled fields
+    input,
+    select,
+    textarea {
+
+      // Position label above field
+      &:focus,
+      &:not(.ng-empty) {
+        & + label {
+          top: -$space;
+          font-size: $font-size-s;
+          font-weight: $global-weight-bold;
+        }
       }
-    }
-    &.is-dirty {
-      label {
-        color: $adk-quicksilver;
-      }
-    }
-    &.is-wrong.is-focused {
-      label {
-        color: $adk-red;
-      }
-    }
-    &.is-focused {
-      label {
-        color: $adk-blue;
+
+      // Blue label when valid
+      &:focus:not(.ng-invalid) {
+        & + label {
+          color: $adk-blue;
+        }
       }
     }
   }
-
 }

--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -1,7 +1,10 @@
 // Text Inputs - get rid of box shadow
 textarea, input {
+  &:hover {
+    border: $input-border-hover;
+  }
   &:focus {
-    border-bottom: $thick-underline-hover;
+    border: $input-border-focus;
   }
 }
 input[type="checkbox"] + label,

--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -119,57 +119,107 @@ $minimal-field-input-border: $input-border;
 $minimal-field-input-border-focus: $thick-underline-hover;
 $minimal-field-input-border-error: 2px solid $adk-red;
 
+// Regular field styles for minimal fields
+@mixin minimal-field-element {
+  @include minimal-animation-default();
+  @include minimal-field-label;
+
+  border: none;
+  border-bottom: $minimal-field-input-border;
+  border-radius: 0;
+  background-color: transparent;
+  box-shadow: none;
+  margin: 0;
+  padding-left: 0;
+
+  &:hover {
+    border: 0;
+    border-bottom: $input-border-hover;
+  }
+
+  &:focus {
+    border: 0;
+    border-bottom: $minimal-field-input-border-focus;
+  }
+}
+
+@mixin minimal-field-label {
+  // Blue label when focused
+  &:focus:not(.ng-invalid),
+  &.focus:not(.ng-invalid) {
+    & + label {
+      color: $adk-blue;
+    }
+  }
+}
+
+// Error styles for minimal fields
+@mixin minimal-field-element-errors {
+  // Field errors
+  &.ng-invalid {
+    margin-bottom: 0;
+    background-color: transparent;
+    border-bottom: $minimal-field-input-border-error;
+
+    // Red label
+    & + label {
+      color: $adk-red;
+    }
+
+  }
+  // Red error messages
+  & ~ span[ng-messages] {
+    position: absolute;
+    color: $adk-red;
+    font-size: $font-size-s;
+  }
+}
+
+// Styles when a floating-label input is focused or filled
+@mixin minimal-field-filled-focused {
+  // Position label above field
+  & + label {
+    top: -$space;
+    font-size: $font-size-s;
+    font-weight: $global-weight-bold;
+  }
+}
+
+
 .minimal-field {
   position: relative;
-  margin: $space 0;
+  margin-top: $space;       // Top margin so the label has a place to go when it floats
+  margin-bottom: $space-m;  // Bottom margin so that error messages don't bump into labels on consecutive fields
+  margin-left: 0;
+  margin-right: 0;
 
-  // Field
+  // Regular elements
   input,
+  input:not(.selectize-input),
   select,
   textarea {
-    @include minimal-animation-default();
-    border: none;
-    border-bottom: $minimal-field-input-border;
-    border-radius: 0;
-    background-color: transparent;
-    box-shadow: none;
+    @include minimal-field-element;
+    @include minimal-field-element-errors;
+  }
+
+  // Selectize-specific
+  .selectize-control .selectize-input {
+    @include minimal-field-element;
+    @include minimal-field-element-errors;
+
     margin: 0;
-    padding-left: 0;
+  }
 
-    &:hover {
-      border: 0;
-      border-bottom: $input-border-hover;
-    }
+  .selectize-control {
+    @include minimal-field-label;
+  }
 
-    &:focus {
-      border: 0;
-      border-bottom: $minimal-field-input-border-focus;
-    }
+  .selectize-control.focus {
+    border-bottom: $minimal-field-input-border-focus;
+  }
 
-    // Blue label when focused
-    &:focus:not(.ng-invalid) {
-      & + label {
-        color: $adk-blue;
-      }
-    }
-
-    // Field errors
-    &.ng-invalid {
-      margin-bottom: 0;
-      background-color: transparent;
-      border-bottom: $minimal-field-input-border-error;
-
-      // Red label
-      & + label {
-        color: $adk-red;
-      }
-
-      // Red error messages
-      & ~ span[ng-messages] {
-        color: $adk-red;
-        font-size: $font-size-s;
-      }
-    }
+  .selectize-control .selectize-input.has-items {
+    padding: 0;
   }
 
   // Label
@@ -187,18 +237,26 @@ $minimal-field-input-border-error: 2px solid $adk-red;
 
     // Focused/filled fields
     input,
-    select,
     textarea {
-
-      // Position label above field
       &:focus,
       &:not(.ng-empty) {
-        & + label {
-          top: -$space;
-          font-size: $font-size-s;
-          font-weight: $global-weight-bold;
-        }
+        @include minimal-field-filled-focused;
       }
     }
+
+    select {
+      &:not(.ng-empty) {
+        @include minimal-field-filled-focused;
+      }
+    }
+
+    // Selectize-specific
+    .selectize-control {
+      &.focus,
+      &:not(.ng-empty) {
+        @include minimal-field-filled-focused;
+      }
+    }
+
   }
 }

--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -136,14 +136,27 @@ $minimal-field-input-border-error: 2px solid $adk-red;
     margin: 0;
     padding-left: 0;
 
+    &:hover {
+      border: 0;
+      border-bottom: $input-border-hover;
+    }
+
     &:focus {
       border: 0;
       border-bottom: $minimal-field-input-border-focus;
     }
 
+    // Blue label when focused
+    &:focus:not(.ng-invalid) {
+      & + label {
+        color: $adk-blue;
+      }
+    }
+
     // Field errors
     &.ng-invalid {
       margin-bottom: 0;
+      background-color: transparent;
       border-bottom: $minimal-field-input-border-error;
 
       // Red label
@@ -165,13 +178,10 @@ $minimal-field-input-border-error: 2px solid $adk-red;
       @include minimal-animation-default();
       position: absolute;
       display: block;
-
       bottom: 0;
       top: $space-xxs;
-
       font-size: $input-font-size;
       font-weight: $global-weight-normal;
-
       pointer-events: none;
     }
 
@@ -187,13 +197,6 @@ $minimal-field-input-border-error: 2px solid $adk-red;
           top: -$space;
           font-size: $font-size-s;
           font-weight: $global-weight-bold;
-        }
-      }
-
-      // Blue label when valid
-      &:focus:not(.ng-invalid) {
-        & + label {
-          color: $adk-blue;
         }
       }
     }

--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -219,14 +219,13 @@ $minimal-field-input-border-error: 2px solid $adk-red;
 
 .minimal-field {
   position: relative;
-  margin-top: $space;       // Top margin so the label has a place to go when it floats
+  margin-top: $space;       // Top margin so the label has a place to go when it floats up
   margin-bottom: $space-m;  // Bottom margin so that error messages don't bump into labels on consecutive fields
   margin-left: 0;
   margin-right: 0;
 
   // Regular elements
   input,
-  input:not(.selectize-input),
   select,
   textarea {
     @include minimal-field-element;
@@ -234,23 +233,23 @@ $minimal-field-input-border-error: 2px solid $adk-red;
   }
 
   // Selectize-specific
-  .selectize-control .selectize-input {
-    @include minimal-field-element;
-    @include minimal-field-element-errors;
-
-    margin: 0;
-  }
-
   .selectize-control {
     @include minimal-field-label;
+
+    .selectize-input {
+      @include minimal-field-element;
+      @include minimal-field-element-errors;
+      margin: 0;
+
+      &.has-items {
+        padding: 0 !important; // !important because the regular Selectize styles get compiled later in the output CSS file, so they overwrite this rule without !important
+      }
+    }
+    
   }
 
-  .selectize-control.focus {
-    border-bottom: $minimal-field-input-border-focus;
-  }
-
-  .selectize-control .selectize-input.has-items {
-    padding: 0;
+  .selectize-dropdown {
+    border-top: $minimal-field-input-border-focus;
   }
 
   // Label
@@ -266,7 +265,7 @@ $minimal-field-input-border-error: 2px solid $adk-red;
       pointer-events: none;
     }
 
-    // Focused/filled fields
+    // Filled/focused: Input/textarea
     input,
     textarea {
       &:focus,
@@ -275,15 +274,17 @@ $minimal-field-input-border-error: 2px solid $adk-red;
       }
     }
 
+    // Filled/focused: Select
     select {
+      // Can't use :focus here because the label will still move up when the element is clicked even though it doesn't have a value yet
       &:not(.ng-empty) {
         @include minimal-field-filled-focused;
       }
     }
 
-    // Selectize-specific
+    // Filled/focused: Selectize
     .selectize-control {
-      &.focus,
+      &.focus, // .focus class is added/removed by the Selectize directive when the 'focus'/'blur' Selectize events are fired
       &:not(.ng-empty) {
         @include minimal-field-filled-focused;
       }

--- a/scss/_adk-selectize.scss
+++ b/scss/_adk-selectize.scss
@@ -254,7 +254,7 @@
 }
 .selectize-dropdown {
   position: absolute;
-  z-index: 10;
+  z-index: 2000;
   border: $input-border-focus;
   border-top: 1px solid rgba($adk-gunmetal, 0.2);
   background: #ffffff;


### PR DESCRIPTION
These changes refactor some of the classes/functionality for minimal fields so that they don't rely on jQuery (or other JavaScript) to manipulate positioning.

![fsc80wld4w](https://user-images.githubusercontent.com/3157928/29175747-e53b47a6-7db7-11e7-9bb5-0965f19645d9.gif)


### Angular-specific things to note
These now use the Angular `ng-invalid` or `ng-empty`-type classes to set error state or placeholder positioning on the fields. I did it this way because I'd rather extend our design kit than change the way Angular assigns "error" or "empty" classes. I figured this was safe enough since we don't use these fields outside of Angular forms currently.

### Documentation update
I added usage instructions to the documentation.

Just add `.minimal-field` and `.floating-label` classes to the parent div, and be sure the contents are in the following order:
1. Field (input, select, or textarea element)
1. Label (label element with the placeholder/floating label contents)
1. Errors (span element with `ng-messages` defined on it for Angular form validation)

Preview:
![image](https://user-images.githubusercontent.com/3157928/29174272-ceb14cdc-7db3-11e7-8c62-e3216e479309.png)
