### PR TITLE
Fix textarea min-height

### DIFF
--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -7,6 +7,11 @@ textarea, input {
     border: $input-border-focus;
   }
 }
+
+textarea {
+  min-height: initial;
+}
+
 input[type="checkbox"] + label,
 input[type="radio"] + label,  {
   color: $black;


### PR DESCRIPTION
Foundation specifies 50px as the default min-height on textareas (in _global.scss from the source files)
(From Foundation's base files):
![image](https://user-images.githubusercontent.com/3157928/29323431-e3ca6208-81ae-11e7-9063-636075f608e0.png)


This is incompatible with our minimal fields and also not necessarily a desired behavior because 50px is arbitrary and doesn't tie to any of the spacing variables we use in Design Kit

These changes overwrite the Foundation default min-height for textareas to use initial values set in other parts of Foundation