### PR TITLE
Add `header` and `footer` styles for Foundation modals

### DIFF
--- a/scss/_adk-modals.scss
+++ b/scss/_adk-modals.scss
@@ -16,24 +16,39 @@
 }
 
 .reveal {
+
+  .header, .footer {
+    background-color: transparent;
+  }
+
   .header {
     @include full-width-border(bottom)
+
+    // Allows for the header to span the full width of parent
+    width: auto;
 
     // Add bottom margin inside header content
     margin-bottom: $global-margin;
 
     // Add space between header and modal content below
     padding-bottom: $global-padding;
+
+    padding-top: 0;
   }
 
   .footer {
     @include full-width-border(top)
+
+    // Allows for the footer to span the full width of parent
+    width: auto;
 
     // Add top margin inside footer content
     margin-top: $global-margin;
 
     // Add space between footer and modal content above
     padding-top: $global-margin;
+
+    padding-bottom: 0;
   }
 }
 


### PR DESCRIPTION
Making sure they are not affected by the more general `.header` and `.footer` global styles.
__Before:__
![before](https://user-images.githubusercontent.com/1562309/32518415-78ce92ba-c3d7-11e7-9b41-aa42cff92b46.png)


__After:__
![after](https://user-images.githubusercontent.com/1562309/32518422-7e7751de-c3d7-11e7-9015-8fa1ee533142.png)
