### PR TITLE
Card transition and styling

### DIFF
--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -3,6 +3,7 @@
   padding: $card-padding;
   overflow: initial;
   position: relative;
+  border: 1px solid rgba($adk-gunmetal, 0.4);
 
   &.multi-image {
     // `multi-image` card wraps a container div around image items.

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -88,10 +88,10 @@
     box-shadow: 0 0 0 2px transparent;
     // transition: box-shadow, 0.12s;
     &:hover {
-      box-shadow: 0 0 16px rgba($adk-quicksilver, 0.7);
+      box-shadow: 0 0 12px rgba($adk-quicksilver, 0.4);
     }
     &:active {
-      box-shadow: 0 0 2px 2px rgba($adk-blue, 0.5);
+      box-shadow: 0 0 2px 2px rgba($adk-blue, 0.4);
       border-color: $adk-blue;
     }
   }

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -87,7 +87,7 @@
   &.clickable {
     cursor: pointer;
     box-shadow: 0 0 0 2px transparent;
-    // transition: box-shadow, 0.12s;
+    transition: box-shadow 100ms cubic-bezier(0.215,.61,.355,1);
     &:hover {
       box-shadow: 0 0 12px rgba($adk-quicksilver, 0.4);
     }


### PR DESCRIPTION
Lightening the card border to make less heavy handed and also bringing back the hover transition to make it less jarring. We removed the transition when implementing masonry because it was causing some flickering, but I don’t seem to be experiencing that anymore. If masonry cards are working well with this PR then it would be nice! Here’s darrel’s previous commit for ref: 

https://github.com/Architizer/design-kit/commit/ffcd4c30ed5275e0408f7c4e5b1672569e2ba6c5