### PR TITLE
Darell/recommended product card

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -924,12 +924,25 @@ The examples below are the three main image-based card types on Source. They are
           <div class="small-10 columns mt-xs">
             <!-- Product Name -->
             <div class="row">
-              <strong class="ellipsis">Knoll Executive Table</strong>
+              <strong class="ellipsis">Knoll Custom Teak Executive Table</strong>
             </div>
-            <!-- Brand Name -->
-            <div class="row align-middle">
-              <div class="columns shrink meta pr-0">
-                <h6 class="fs-base">Knoll</h6>
+            <div class="row">
+              <!-- Brand Name -->
+              <div class="columns shrink subtitle fs-base ellipsis pr-xs"
+                   style="max-width: calc(100% - 55px);">Knoll United States of America</div>
+              <div class="columns small-3"
+                   style="min-width: 55px;">
+                <div class="row">
+                  <!-- Verified Badge -->
+                  <div class="columns shrink pl-0 pr-xxs">
+                    <span class="architizer-glyph blue-500 fs-l"
+                          style="display:inline-block; line-height: 1;">+</span>
+                  </div>
+                  <!-- Pro Badge -->
+                  <div class="columns shrink pl-0">
+                    <span class="blue capitalize fs-s fw-bold">PRO</span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/docs.md
+++ b/docs.md
@@ -715,7 +715,7 @@ The examples below are the three main image-based card types on Source. They are
 **Search Cards** - Displays search title and # of products inside. Mosaic of floating product images as card content.  
 **Product Cards** - Displays product and brand names (note smaller type size) with product action button. 4:3 fixed width card-image ratio displaying product image and creator info on hover overlay.  
 **Product Cards, not clickable** - Product cards that are not in the context of a mosaic grid, such as cards in a message thread, are not clickable objects. Therefore these cards must have a dedicated "View Product" button.  
-**Recommended Product Cards, clickable** - Displays recommended product and brand name (along with PRO badge if application) with an add button. 4:3 fixed width card-image ratio.
+**Recommended Product Cards, clickable** - Displays recommended product and brand name (along with PRO badge if applicable) with an add button. 4:3 fixed width card-image ratio.
 
 ```html_example
 <div class="row small-up-1 medium-up-2 large-up-3">

--- a/docs.md
+++ b/docs.md
@@ -714,7 +714,8 @@ The examples below are the three main image-based card types on Source. They are
 **Project Cards** - Displays project title and phase with edit button. 16:9 fixed width card-image ratio w/ information on hover.  
 **Search Cards** - Displays search title and # of products inside. Mosaic of floating product images as card content.  
 **Product Cards** - Displays product and brand names (note smaller type size) with product action button. 4:3 fixed width card-image ratio displaying product image and creator info on hover overlay.  
-**Product Cards, not clickable** - Product cards that are not in the context of a mosaic grid, such as cards in a message thread, are not clickable objects. Therefore these cards must have a dedicated "View Product" button.
+**Product Cards, not clickable** - Product cards that are not in the context of a mosaic grid, such as cards in a message thread, are not clickable objects. Therefore these cards must have a dedicated "View Product" button.  
+**Recommended Product Cards, clickable** - Displays recommended product and brand name (along with PRO badge if application) with an add button. 4:3 fixed width card-image ratio.
 
 ```html_example
 <div class="row small-up-1 medium-up-2 large-up-3">

--- a/docs.md
+++ b/docs.md
@@ -928,10 +928,12 @@ The examples below are the three main image-based card types on Source. They are
             </div>
             <div class="row">
               <!-- Brand Name -->
+              <!-- Brand name column width needs to be calculated so that the addition of the PRO badge doesn't cause a column break -->
               <div class="columns shrink subtitle fs-base ellipsis pr-xs"
                    style="max-width: calc(100% - 55px);">Knoll United States of America</div>
               <div class="columns small-3"
                    style="min-width: 55px;">
+                <!-- PRO badge width is fixed at 55px so that brand name column can be calculated accordingly -->
                 <div class="row">
                   <!-- Verified Badge -->
                   <div class="columns shrink pl-0 pr-xxs">

--- a/docs.md
+++ b/docs.md
@@ -872,7 +872,7 @@ The examples below are the three main image-based card types on Source. They are
 </div>
 <div class="row small-up-1 medium-up-2 large-up-3">
   <div class="column">
-    <!-- Product Card Flex-->
+    <!-- Card 4 - Product Card Flex-->
     <div class="card flex">
       <!-- Card Image -->
       <div class="card-section card-image card-image-no-margin"
@@ -912,7 +912,40 @@ The examples below are the three main image-based card types on Source. They are
     </div>
   </div>
   <div class="column">
-    <!-- Card 4 - Multi Image Card -->
+    <!-- Card 5 - Recommended Product Card Fixed-->
+    <div class="card clickable recommended">
+      <!-- Card Image -->
+      <div class="card-section card-image card-image-no-margin"
+           style="background-image: url('/docs/img/table.jpg')"></div>
+      <!-- Card Content -->
+      <div class="card-section">
+        <div class="row align-middle">
+          <div class="small-10 columns mt-xs">
+            <!-- Product Name -->
+            <div class="row">
+              <strong class="ellipsis">Knoll Executive Table</strong>
+            </div>
+            <!-- Brand Name -->
+            <div class="row align-middle">
+              <div class="columns shrink meta pr-0">
+                <h6 class="fs-base">Knoll</h6>
+              </div>
+            </div>
+          </div>
+          <!-- '+' button -->
+          <div class="small-2 columns" style="white-space: nowrap;">
+            <div class="float-right">
+              <a class="button tiny">
+                <span class="material-icons fs-base">add</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="column">
+    <!-- Card 6 - Multi Image Card -->
     <div class="card multi-image clickable masonry">
     <!-- Image -->
       <div class="card-section">

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -93,6 +93,10 @@
       }
     }
 
+    .subtitle {
+      color: $light-gray;
+    }
+
     // Medium breakpoint width
     @include breakpoint(medium) {
       width: $card-size-xsmall;

--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -77,6 +77,35 @@
     }
   }
 
+  &.recommended {
+    float: left;
+    margin-right: $space-xs;
+    padding-bottom: $space-xxxs;
+    display: inline-block;
+    // Small breakpoint width
+    width: $card-size-xxsmall;
+
+    .card-image {
+      height: $card-size-xxsmall / 1.33;  //4:3 by default
+      &.ratio-16-9 {
+        height: $card-size-xxsmall / 1.77;
+        width: inherit;
+      }
+    }
+
+    // Medium breakpoint width
+    @include breakpoint(medium) {
+      width: $card-size-xsmall;
+      .card-image {
+        height: $card-size-xsmall / 1.33;
+        &.ratio-16-9 {
+          height: $card-size-xsmall / 1.77;
+          width: inherit;
+        }
+      }
+    }
+  }
+
   // // Use flex class to overide fixed width and use the grid to size the card instead
   // &.flex {
   //   width: inherit;

--- a/scss/_adk-variables.scss
+++ b/scss/_adk-variables.scss
@@ -173,6 +173,8 @@ $card-content-margin: 0 0 $space-xxs 0;
 // Card sizes
 $card-size-base: 360px;
 $card-size-small: 320px;
+$card-size-xsmall: 270px;
+$card-size-xxsmall: 230px;
 
 
 /**


### PR DESCRIPTION
PR to add Recommended Product card template example into ADK:

- Displays recommended product and brand name (along with PRO badge if applicable) with an add button. Clickable. 4:3 fixed width card-image ratio.

![screen shot 2018-01-08 at 3 44 55 pm](https://user-images.githubusercontent.com/11481550/34691575-fb93b912-f48a-11e7-86fb-4250d56bddb5.png)

![screen shot 2018-01-08 at 3 45 55 pm](https://user-images.githubusercontent.com/11481550/34691600-1088cede-f48b-11e7-93a9-b4f9009f1843.png)


  