### PR TITLE
Darell/pro-and-beta-badges

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1074,8 +1074,8 @@ For the sake of convenience, here is the markup and css classes required to rend
 
 ## BETA Badge
 
-BETA badge is currently used in the Recommended Products Grid header description, and can also be used for other new features that we are still evaluating or testing. It has the same font height
-and weight as the Pro badge above.
+BETA badge is currently used in the Recommended Products grid header description, and can also be used for other new features that we are still evaluating or testing. It is applied as a class in conjunction with Foundation's `badge` class and has the same font height
+and weight as the Pro badge.
 For the sake of convenience, here is the markup and css classes required to render it in any given context.
 
 ### Example
@@ -1083,9 +1083,8 @@ For the sake of convenience, here is the markup and css classes required to rend
 <!-- Description -->
 <div class="row align-middle">
   <!-- BETA badge -->
-  <div class="columns shrink pl-0 pr-0 pt-0 pb-xxxs">
-    <span class="white badge capitalize fs-s fw-bold p-xs"
-          style="line-height: 0.25; height: 18px; border-radius: 15px; vertical-align: middle;">BETA</span>
+  <div class="columns shrink">
+    <span class="white beta badge capitalize fs-s fw-bold">BETA</span>
   </div>
 </div>
 ```

--- a/docs.md
+++ b/docs.md
@@ -1074,7 +1074,8 @@ For the sake of convenience, here is the markup and css classes required to rend
 
 ## BETA Badge
 
-BETA badge is used in the Recommended Products Grid header description and can also be used for other feature to indicate a new feature that we are still evaluating or testing.
+BETA badge is currently used in the Recommended Products Grid header description, and can also be used for other new features that we are still evaluating or testing. It has the same font height
+and weight as the Pro badge above.
 For the sake of convenience, here is the markup and css classes required to render it in any given context.
 
 ### Example

--- a/docs.md
+++ b/docs.md
@@ -937,12 +937,11 @@ The examples below are the three main image-based card types on Source. They are
                 <div class="row">
                   <!-- Verified Badge -->
                   <div class="columns shrink pl-0 pr-xxs">
-                    <span class="architizer-glyph blue-500 fs-l"
-                          style="display:inline-block; line-height: 1;">+</span>
+                    <span class="verified">+</span>
                   </div>
                   <!-- Pro Badge -->
                   <div class="columns shrink pl-0">
-                    <span class="blue capitalize fs-s fw-bold">PRO</span>
+                    <span class="pro">PRO</span>
                   </div>
                 </div>
               </div>
@@ -1059,13 +1058,12 @@ For the sake of convenience, here is the markup and css classes required to rend
 <div class="row">
   <!-- Verified Badge -->
   <div class="columns shrink pl-0 pr-xxs">
-    <span class="architizer-glyph blue-500 fs-l"
-          style="display:inline-block; line-height: 1;">+
+    <span class="verified">+
     </span>
   </div>
   <!--  Pro Badge -->
   <div class="columns shrink pl-0">
-    <span class="blue capitalize fs-s fw-bold">PRO</span>
+    <span class="pro">PRO</span>
   </div>
 </div>
 ```
@@ -1084,7 +1082,7 @@ For the sake of convenience, here is the markup and css classes required to rend
 <div class="row align-middle">
   <!-- BETA badge -->
   <div class="columns shrink">
-    <span class="white beta badge capitalize fs-s fw-bold">BETA</span>
+    <span class="beta badge">BETA</span>
   </div>
 </div>
 ```

--- a/docs.md
+++ b/docs.md
@@ -1072,6 +1072,25 @@ For the sake of convenience, here is the markup and css classes required to rend
 
 ---
 
+## BETA Badge
+
+BETA badge is used in the Recommended Products Grid header description and can also be used for other feature to indicate a new feature that we are still evaluating or testing.
+For the sake of convenience, here is the markup and css classes required to render it in any given context.
+
+### Example
+```html_example
+<!-- Description -->
+<div class="row align-middle">
+  <!-- BETA badge -->
+  <div class="columns shrink pl-0 pr-0 pt-0 pb-xxxs">
+    <span class="white badge capitalize fs-s fw-bold p-xs"
+          style="line-height: 0.25; height: 18px; border-radius: 15px; vertical-align: middle;">BETA</span>
+  </div>
+</div>
+```
+
+---
+
 ## List Views & Items
 
 List views are simple lists that take up 100% of parent element's height and create a minimal scrolling container for list items. Each list item contains a thumbnail, a title and a subtitle plus an optional Pro Badge. In the example below, the outermost div with the inline style of `height: 200px;` is only used to demonstrate the scrolling behavior of the list. 

--- a/scss/_adk-badges.scss
+++ b/scss/_adk-badges.scss
@@ -1,9 +1,27 @@
 // Badge types
 .beta {
-  line-height: 0.25;
+  line-height: .25;
   height: 18px;
   border-radius: 15px;
   vertical-align: middle;
   padding: $space-xs;
   text-transform: uppercase;
+  font-size: .8rem;
+  font-weight: 800;
+  color: #FFF;
+}
+
+.verified {
+  line-height: 1;
+  display: inline-block;
+  color: #1CA3FC;
+  font-size: 1.5625rem;
+  font-family: "Architizer Glyphs";
+}
+
+.pro {
+  color: #1CA3FC;
+  text-transform: uppercase;
+  font-size: .8rem;
+  font-weight: 800;
 }

--- a/scss/_adk-badges.scss
+++ b/scss/_adk-badges.scss
@@ -1,0 +1,9 @@
+// Badge types
+.beta {
+  line-height: 0.25;
+  height: 18px;
+  border-radius: 15px;
+  vertical-align: middle;
+  padding: $space-xs;
+  text-transform: uppercase;
+}

--- a/scss/adk.scss
+++ b/scss/adk.scss
@@ -60,6 +60,7 @@
 
 // Architizer Design Kit styles
 @import 'adk-animations';
+@import 'adk-badges';
 @import 'adk-buttons';
 @import 'adk-colors';
 @import 'adk-cards';


### PR DESCRIPTION
Since we use the PRO badge heavily and plan to use the `BETA` badge for other components too, this PR adds classes, templates and documentation for the aforementioned badges: 

1)  `BETA` badge class: 

![screen shot 2018-01-17 at 12 58 09 pm](https://user-images.githubusercontent.com/11481550/35058513-2bd26450-fb86-11e7-9a79-005e7c3b7eac.png)

2) `PRO` badge class: 

![screen shot 2018-01-17 at 12 58 25 pm](https://user-images.githubusercontent.com/11481550/35058541-42ba6a46-fb86-11e7-8862-6e394f3dab85.png)
