### PR TITLE
Only set hover rules on .inactive cards when the card is clickable

### DIFF
--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -139,7 +139,7 @@
   &.inactive {
     opacity: 0.3;
 
-    &:hover {
+    &.clickable:hover {
       opacity: 1;
     }
   }


### PR DESCRIPTION
I have a use case where I am displaying inactive cards that aren't clickable - the hover styles were still "lighting up" the card on hover, so I fixed these hover styles to only apply to `.inactive.clickable` cards.

Old:
![ialgwtko1f](https://user-images.githubusercontent.com/3157928/35171941-86f56a0e-fd33-11e7-86ec-b2a90ea760a0.gif)

New:
![tyebilr4ba](https://user-images.githubusercontent.com/3157928/35171943-89d02886-fd33-11e7-84cf-377875ead78f.gif)
