### PR TITLE
Add color property to disabled input text label

### DIFF
--- a/scss/_adk-forms.scss
+++ b/scss/_adk-forms.scss
@@ -21,8 +21,10 @@ input[type="text"]:focus {
   background-color: transparent;
 }
 
-input[type="text"]:disabled {
+input[type="text"]:disabled,
+input[type="text"]:disabled + label {
   opacity: 0.3;
+  color: $black;
 }
 
 label {


### PR DESCRIPTION
PR to make the `label` color match that of the disabled input text field: 

![screen shot 2018-01-22 at 1 45 06 pm](https://user-images.githubusercontent.com/11481550/35238668-2d6d7026-ff7c-11e7-98a4-f8d6b224ee44.png)
