### PR TITLE
Add display:block to card class

### DIFF
--- a/scss/_adk-cards.scss
+++ b/scss/_adk-cards.scss
@@ -4,6 +4,7 @@
   overflow: initial;
   position: relative;
   border: 1px solid rgba($adk-gunmetal, 0.4);
+  display: block;
 
   &.responsive-image {
     padding: 0;


### PR DESCRIPTION
Adding display:block to card class. Image issue still exists with firefox whether using css grid or flex. This shouldn’t affect anything across the board.  