### PR TITLE
Darell/tag component

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -981,7 +981,7 @@ For the sake of convenience, here is the markup and css classes required to rend
 
 ## BETA Badge
 
-BETA badge is currently used in the Recommended Products grid header description, and can also be used for other new features that we are still evaluating or testing. It is applied as a class in conjunction with Foundation's `badge` class and has the same font height
+BETA badge is currently used in the Related Products grid header description, and can also be used for other new features that we are still evaluating or testing. It is applied as a class in conjunction with Foundation's `badge` class and has the same font height
 and weight as the Pro badge.
 For the sake of convenience, here is the markup and css classes required to render it in any given context.
 
@@ -992,6 +992,24 @@ For the sake of convenience, here is the markup and css classes required to rend
   <!-- BETA badge -->
   <div class="columns shrink">
     <span class="beta badge">BETA</span>
+  </div>
+</div>
+```
+
+---
+
+## Tags
+
+Tags are currently used in the Brand Profile sidebar and Related Products modal, and can be used for other features that require category tags. Tags are similar to pill buttons, but they do not have a border radius. For the sake of convenience, here is the markup and css classes required to render it in any given context.
+
+### Example
+```html_example
+<div class="row">
+  <div class="columns">
+    <span class="tag">metal panels</span>
+    <span class="tag">sheet panels</span>
+    <span class="tag">steel fabrication</span>
+    <span class="tag">bronze panels</span>
   </div>
 </div>
 ```

--- a/scss/_adk-tags.scss
+++ b/scss/_adk-tags.scss
@@ -1,6 +1,6 @@
 .tag {
 	color: $black;
-	padding: $space-xxs;
+	padding: $space-xxxs;
 	font-size: $font-size-s;
 	background-color: $white;
 	border: 1px solid #b0c0cb;

--- a/scss/_adk-tags.scss
+++ b/scss/_adk-tags.scss
@@ -6,4 +6,5 @@
 	border: 1px solid #b0c0cb;
 	border-radius: 0;
 	cursor: auto;
+	display: inline-block;
 }

--- a/scss/_adk-tags.scss
+++ b/scss/_adk-tags.scss
@@ -1,0 +1,9 @@
+.tag {
+	color: $black;
+	padding: $space-xxs;
+	font-size: $font-size-s;
+	background-color: $white;
+	border: 1px solid #b0c0cb;
+	border-radius: 0;
+	cursor: auto;
+}

--- a/scss/adk.scss
+++ b/scss/adk.scss
@@ -81,6 +81,7 @@
 @import 'adk-tooltip';
 @import 'adk-listview';
 @import 'adk-type';
+@import 'adk-tags';
 
 // Architizer Design Kit mixins
 @include adk-foundation-button;


### PR DESCRIPTION
Adds the `tag` component to ADK as we are now using it in the Related Products modal as well as the Brand Profile sidebar:

![screen shot 2018-01-23 at 11 58 19 am](https://user-images.githubusercontent.com/11481550/35289247-be58c6fe-0034-11e8-9ecb-5d8e1e8e086e.png)

<img width="239" alt="screen shot 2018-01-23 at 11 00 11 am" src="https://user-images.githubusercontent.com/11481550/35289256-c4022e06-0034-11e8-98d3-12c50b7487a7.png">

![screen shot 2018-01-23 at 10 39 22 am](https://user-images.githubusercontent.com/11481550/35289252-c13d4a34-0034-11e8-9362-0de74416b6bc.png)
 