### PR TITLE
Update styles for Tabs

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -576,15 +576,15 @@ $table-head-font-color: $medium-gray;
 // // --------
 
 // $tab-margin: 0;
-// $tab-background: $white;
-$tab-color: map-get(generate-palette($adk-quicksilver), 600);
-$tab-background-active: $global-selected;
-$tab-active-color: map-get(generate-palette($adk-quicksilver), 900);
+$tab-background: none;
+$tab-color: $adk-quicksilver;
+$tab-background-active: none;
+$tab-active-color: $dark-gray;
 $tab-item-font-size: $space;
 $tab-item-background-hover: $global-hover;
-$tab-item-padding: 0.8rem 1.2rem;
+$tab-item-padding: $space;
 // $tab-expand-max: 6;
-// $tab-content-background: $white;
+$tab-content-background: none;
 $tab-content-border: none;
 // $tab-content-color: $body-font-color;
 // $tab-content-padding: 1rem;


### PR DESCRIPTION
This updates the styles used for the Foundation Tabs component

I removed background colors from the tab elements themselves so that they can inherit the background of their parent.

We use these in the Shortlist/Dismissed sidebar on the Products view:
![rry7bppa6o](https://user-images.githubusercontent.com/3157928/35593397-d0520024-05dd-11e8-9200-c340f4de47b2.gif)
