### PR TITLE
Add `short` variant to `dropzone` styles

### DIFF
--- a/scss/_adk-dropzone.scss
+++ b/scss/_adk-dropzone.scss
@@ -96,6 +96,14 @@
 }
 .dropzone {
 
+  &.short {
+    min-height: $space-m;
+
+    .dz-message {
+      margin: 0;
+    }
+  }
+
   $image-size: 120px;
 
   &:hover {


### PR DESCRIPTION
- Adds `short` class to `dropzone` for design cases like below.

<img width="636" alt="screen shot 2018-02-23 at 11 11 09 am" src="https://user-images.githubusercontent.com/1562309/36603924-483af21c-188a-11e8-89c4-2993a47f6395.png">
