### PR TITLE
Darell/dev 5589/fix pro beta badge

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -972,19 +972,20 @@ The examples below are the main image-based card types on Architizer.
               <div class="columns small-3"
                    style="min-width: 55px;">
                 <!-- PRO badge width is fixed at 55px so that brand name column can be calculated accordingly -->
-                <div class="row">
+                <div class="row align-middle">
                   <!-- Verified Badge -->
-                  <div class="columns shrink pl-0 pr-xxs">
+                  <div class="columns shrink pl-0 pr-xxs pb-xxxs">
                     <span class="verified">+</span>
                   </div>
                   <!-- Pro Badge -->
-                  <div class="columns shrink pl-0">
+                  <div class="columns shrink pl-0 pb-xs">
                     <span class="pro">PRO</span>
                   </div>
                 </div>
               </div>
             </div>
           </div>
+
           <!-- Shortlist checkmark button -->
           <div class="small-2 columns"
                style="white-space: nowrap;">
@@ -1012,14 +1013,14 @@ For the sake of convenience, here is the markup and css classes required to rend
 
 ### Example
 ```html_example
-<div class="row">
+<div class="row align-middle">
   <!-- Verified Badge -->
-  <div class="columns shrink pl-0 pr-xxs">
+  <div class="columns shrink pt-xxxs pl-0 pr-xxs">
     <span class="verified">+
     </span>
   </div>
   <!--  Pro Badge -->
-  <div class="columns shrink pl-0">
+  <div class="columns shrink pl-0 pb-xxxs">
     <span class="pro">PRO</span>
   </div>
 </div>

--- a/docs.md
+++ b/docs.md
@@ -1086,7 +1086,7 @@ For the sake of convenience, here is the markup and css classes required to rend
 <!-- BETA badge -->
 <div class="row align-middle">
   <div class="columns shrink pl-0 pr-0">
-    <span class="beta badge fs-s fw-bold mt-xxs">beta</span>
+    <span class="beta">beta</span>
   </div>
 </div>
 ```

--- a/scss/_adk-badges.scss
+++ b/scss/_adk-badges.scss
@@ -1,14 +1,16 @@
 // Badge types
 .beta {
-  line-height: 1;
+  line-height: 0.8;
   border-radius: 15px;
   vertical-align: middle;
   display: inline-block;
-  padding: $space-xxxs $space-xxs;
+  padding: .15rem .4rem .35rem .4rem;
   color: $white;
   font-size: $font-size-s;
+  font-weight: 600;
+  background: $adk-blue;
+  text-align: center;
   @include smallcaps;
-  @include weight-medium;
 }
 
 .verified {

--- a/scss/_adk-badges.scss
+++ b/scss/_adk-badges.scss
@@ -15,14 +15,13 @@
   line-height: 1;
   display: inline-block;
   color: $adk-blue;
-  font-size: 1.5625rem;
+  font-size: $font-size-l;
   font-family: "Architizer Glyphs";
 }
 
 .pro {
   color: $adk-blue;
-  font-size: $font-size-s;
+  font-size: $font-size;
+  font-weight: 600;
   @include smallcaps;
-  @include weight-medium;
-
 }


### PR DESCRIPTION
PR to fix styling of BETA, PRO and Verified badge due to Neue Haas font change:

- Includes removal of unnecessary `.badge` and font-style classes for the BETA badge

PRO: 
![screen shot 2018-02-28 at 3 19 14 pm](https://user-images.githubusercontent.com/11481550/36811151-cdcb9404-1c9a-11e8-89d3-e9a9e39d78c1.png)

BETA: 
![screen shot 2018-02-28 at 3 17 09 pm](https://user-images.githubusercontent.com/11481550/36811111-adf283ae-1c9a-11e8-90d9-cb55bb22d371.png)
