### PR TITLE
Mani/dev 5630/help center

### DIFF
--- a/scss/_adk-layout.scss
+++ b/scss/_adk-layout.scss
@@ -50,16 +50,28 @@
   background-color: $black;
   border-bottom: $global-separator;
 
-  .menu a:hover {
-    color: $white;
-  }
+  .menu {
+    a {
+      line-height: 1.5;
+    }
 
-  .menu a {
-    line-height: 1.5;
-  }
+    .active > a,
+    a:hover {
+      color: $white;
+    }
+    
+    .light {
+      background-color: $white;
 
-  .active > a {
-    color: $white;
+      a {
+        color: $black;
+      }
+
+      .active > a,
+      a:hover {
+        color: $adk-blue;
+      }
+    }
   }
 
 }

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -341,7 +341,7 @@ $dropdown-padding: $space;
 // $dropdown-background: $body-background;
 $dropdown-border: none;
 $dropdown-font-size: $font-size;
-// $dropdown-width: 300px;
+$dropdown-width: 220px;
 // $dropdown-radius: $global-radius;
 // $dropdown-sizes: (
 //   tiny: 100px,


### PR DESCRIPTION
- Create `.light` variation on menus
- Globally makes dropdown more narrow, overriding Foundation base settings
![screen shot 2018-03-01 at 5 40 15 pm](https://user-images.githubusercontent.com/1562309/36873813-a3ab9cea-1d77-11e8-8208-6447cfcbca24.png)
