### PR TITLE
Restore light gray border for tags

### DIFF
--- a/scss/_adk-tags.scss
+++ b/scss/_adk-tags.scss
@@ -3,7 +3,7 @@
 	padding: $space-xxs $space-s;
 	font-size: $font-size-s;
 	background-color: $white;
-	// border: 1px solid #b0c0cb;
+	border: 1px solid #b0c0cb;
 	cursor: auto;
 	display: inline-block;
 }


### PR DESCRIPTION
PR to restore removed light gray border for `.tag` class:

![screen shot 2018-03-07 at 3 16 13 pm](https://user-images.githubusercontent.com/11481550/37115874-819f5d4c-221a-11e8-8f63-2c5137deebf9.png)
