### PR TITLE
Align tag text vertically by reducing top padding

### DIFF
--- a/scss/_adk-tags.scss
+++ b/scss/_adk-tags.scss
@@ -1,6 +1,6 @@
 .tag {
 	color: $adk-quicksilver;
-	padding: $space-xxs $space-s;
+	padding: $space-xxxs $space-s $space-xxs $space-s;
 	font-size: $font-size-s;
 	background-color: $white;
 	border: 1px solid #b0c0cb;


### PR DESCRIPTION
PR to align tag text vertically by reducing top padding:

Before:
![screen shot 2018-03-07 at 5 23 04 pm](https://user-images.githubusercontent.com/11481550/37121792-42db950a-222c-11e8-9a53-5e91c40e9bf5.png)

After: 
![screen shot 2018-03-07 at 5 22 44 pm](https://user-images.githubusercontent.com/11481550/37121797-46404ae2-222c-11e8-9220-e449c9333987.png)
