### PR TITLE
Darell/pseudotiers grid

### DIFF
--- a/scss/_adk-layout.scss
+++ b/scss/_adk-layout.scss
@@ -153,7 +153,7 @@
   }
 }
 
-// Card Grid
+// Pseudotiers list grid (BPM landing page)
 .list-grid {
   display: grid;
   grid-template-columns: repeat(1, 1fr);

--- a/scss/_adk-layout.scss
+++ b/scss/_adk-layout.scss
@@ -140,9 +140,41 @@
       grid-column: span 4;
     }
   }
-
   .card {
     margin:0;
+  }
+}
+
+// Card Grid
+.list-grid {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  grid-template-rows: auto 1fr;
+  grid-column-gap: $space-l;
+  span {
+    grid-column: span 1;
+  }
+  @include breakpoint(medium) {
+    grid-template-columns: repeat(2, 1fr);
+    span {
+      grid-column: span 2;
+    }
+  }
+  @include breakpoint(large) {
+    grid-template-columns: repeat(3, 1fr);
+    span {
+      grid-column: span 3;
+    }
+  }
+  @include breakpoint(xlarge) {
+    grid-template-columns: repeat(4, 1fr);
+    span {
+      grid-column: span 4;
+    }
+  }
+  a {
+    font-size: $font-size-s;
+    border-bottom: 1px solid $adk-blue;
   }
 }
 


### PR DESCRIPTION
PR to add the `.list-grid` class in `adk-layout.scss`:
- Used to create dynamic grid layouts for the pseudotiers list section of the BPM landing page

Recording: ![](http://g.recordit.co/u0mQP0jj2O.gif)

X-Large screens:
<img width="728" alt="screen shot 2018-03-21 at 6 09 49 pm" src="https://user-images.githubusercontent.com/11481550/37740174-338ea4cc-2d33-11e8-98c9-c3f53513f691.png">

Large screens:
<img width="742" alt="screen shot 2018-03-21 at 6 10 38 pm" src="https://user-images.githubusercontent.com/11481550/37740192-432356a8-2d33-11e8-8af9-79dc41a44a40.png">

iPad/Medium:
<img width="418" alt="screen shot 2018-03-21 at 6 10 13 pm" src="https://user-images.githubusercontent.com/11481550/37740199-4a73a0de-2d33-11e8-8b0c-ba1b3185073c.png">

Mobile:
<img width="261" alt="screen shot 2018-03-21 at 6 10 24 pm" src="https://user-images.githubusercontent.com/11481550/37740171-30e562c4-2d33-11e8-99dd-37f15f1c2bfe.png">